### PR TITLE
MANTA-3356 prevent user and key enumeration through muskie

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -29,6 +29,7 @@ var vasync = require('vasync');
 var libmanta = require('libmanta');
 var libuuid = require('libuuid');
 var xtend = require('xtend');
+var verror = require('verror');
 
 var common = require('./common');
 require('./errors');
@@ -49,6 +50,9 @@ var SIGN_ALG = {
     'ECDSA-SHA384': true,
     'ECDSA-SHA512': true
 };
+
+
+var PUBLIC_STOR_ROOT = /^\/([a-zA-Z][a-zA-Z0-9_\-\.@%]+)\/public$/;
 
 
 ///--- Helpers
@@ -509,13 +513,14 @@ function loadCaller(req, res, next) {
 
     req.log.debug('loadCaller: entered');
     function gotCaller(err, info) {
+        var innerErr;
         if (err) {
             switch (err.restCode || err.name) {
             case 'AccountDoesNotExist':
-                next(new AccountDoesNotExistError(account));
+                innerErr = new AccountDoesNotExistError(account);
                 break;
             case 'UserDoesNotExist':
-                next(new UserDoesNotExistError(account, user));
+                innerErr = new UserDoesNotExistError(account, user);
                 break;
 
             /*
@@ -525,22 +530,36 @@ function loadCaller(req, res, next) {
              * we ever do support deleting users.
              */
             case 'UserIdDoesNotExist':
-                next(new UserDoesNotExistError(null, userid));
+                innerErr = new UserDoesNotExistError(null, userid);
                 break;
             case 'AccountIdDoesNotExist':
-                next(new AccountDoesNotExistError(accountid));
+                innerErr = new AccountDoesNotExistError(accountid);
                 break;
 
             default:
-                next(new InternalError(err));
+                innerErr = new InternalError(err);
                 break;
             }
+            /*
+             * We don't want to show the details of which of these error
+             * cases it was to the client: that would allow them to enumerate
+             * users and keys that do not belong to them.
+             */
+            next(new InvalidCredentialsError(innerErr));
             return;
         }
 
         if (!info.account.approved_for_provisioning &&
             !info.account.isOperator) {
-            next(new AccountBlockedError(info.account.login));
+            innerErr = new AccountBlockedError(info.account.login);
+            /*
+             * We can't show the user this one either without enabling
+             * enumeration. If we want to change this we would need to alter
+             * the auth process here to do the signature verification before
+             * making this decision (we can tell the user their account is
+             * disabled if we know that they've authenticated as that acct).
+             */
+            next(new InvalidCredentialsError(innerErr));
             return;
         }
 
@@ -595,13 +614,15 @@ function verifySignature(req, res, next) {
 
     var keyId = req.auth.keyId;
     var signature = req.auth.signature;
+    var innerErr;
 
     var keys = user ? user.keys : account.keys;
     if (!keys || !keys[keyId]) {
-        next(new KeyDoesNotExistError(
+        innerErr = new KeyDoesNotExistError(
             account.login,
             keyId,
-            user ? user.login : null));
+            user ? user.login : null);
+        next(new InvalidCredentialsError(innerErr));
         return;
     }
 
@@ -609,11 +630,13 @@ function verifySignature(req, res, next) {
     try {
         var ok = httpSignature.verifySignature(signature, key);
     } catch (e) {
-        next(new InternalError(e));
+        innerErr = new InternalError(e);
+        next(new InvalidCredentialsError(innerErr));
         return;
     }
     if (!ok) {
-        next(new InvalidSignatureError());
+        innerErr = new InvalidSignatureError();
+        next(new InvalidCredentialsError(innerErr));
         return;
     }
 
@@ -690,17 +713,27 @@ function parseHttpAuthToken(req, res, next) {
 
 function loadOwner(req, res, next) {
     var p = req.path();
-    loadOwnerFromPath(req, p, next);
+    loadOwnerFromPath(req, p, res, next);
 }
 
+/*
+ * Generate a fake empty directory response, for a GET /user/public when
+ * the account "user" does not exist.
+ */
+function sendFakeEmptyDir(req, res) {
+    res.header('Content-Type', 'application/x-json-stream; type=directory');
+    res.header('Result-Set-Size', '0');
+    res.send(200);
+    res.end();
+}
 
 /*
  * Extract the owner of a resource based on the input path, verify that
  * the account exists, and set the `owner` field on the request object
  * to the object returned from Mahi.
  */
-function loadOwnerFromPath(req, p, next) {
-    req.log.debug('loadOwner: entered');
+function loadOwnerFromPath(req, p, res, next) {
+    req.log.debug('loadOwnerFromPath: entered');
 
     var account;
     try {
@@ -718,7 +751,31 @@ function loadOwnerFromPath(req, p, next) {
         if (err) {
             switch (err.restCode || err.name) {
             case 'AccountDoesNotExist':
-                next(new AccountDoesNotExistError(account));
+                var login;
+                if (req.caller.anonymous ||
+                    common.PUBLIC_STOR_PATH.test(req.path())) {
+                    login = 'anonymous';
+                } else if (!req.caller.user) {
+                    login = req.caller.account.login;
+                } else {
+                    login = req.caller.account.login + '/' +
+                        req.caller.user.login;
+                }
+                /*
+                 * For non-existent accounts, we want to behave as if it's a
+                 * real account that we have no access to. That means that
+                 * everything should return a 403 AuthorizationError, except
+                 * a GET on /user/public which should return a fake empty
+                 * directory.
+                 */
+                if (PUBLIC_STOR_ROOT.test(req.path()) && req.isReadOnly()) {
+                    sendFakeEmptyDir(req, res);
+                } else if (req.isPublicGet()) {
+                    next(new ResourceNotFoundError(req.path()));
+                    return;
+                }
+                var innerErr = new AccountDoesNotExistError(account);
+                next(new AuthorizationError(login, req.path(), innerErr));
                 return;
             default:
                 next(new InternalError(err));

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -70,15 +70,25 @@ function AuthSchemeError(scheme) {
 util.inherits(AuthSchemeError, MuskieError);
 
 
-function AuthorizationError(login, _path, reason) {
+function AuthorizationError(login, _path, cause) {
     MuskieError.call(this, {
         restCode: 'AuthorizationFailed',
         statusCode: 403,
         message: login + ' is not allowed to access ' + _path,
-        reason: reason
+        cause: cause
     });
 }
 util.inherits(AuthorizationError, MuskieError);
+
+function InvalidCredentialsError(cause) {
+    MuskieError.call(this, {
+        restCode: 'InvalidCredentials',
+        statusCode: 403,
+        message: 'Invalid authorization credentials supplied',
+        cause: cause
+    });
+}
+util.inherits(InvalidCredentialsError, MuskieError);
 
 
 function AuthorizationRequiredError(reason) {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -291,8 +291,10 @@ test('auth caller not found', function (t) {
     rawRequest(opts, function (err, _, __, obj) {
         t.ok(err);
         t.equal(err.statusCode, 403);
-        t.equal(err.restCode, 'AccountDoesNotExist');
+        t.equal(err.restCode, 'InvalidCredentials');
         t.ok(err.message);
+        t.strictEqual(err.message.indexOf('AccountDoesNotExist'), -1);
+        this.firstCredError = err.message;
         t.end();
     });
 });
@@ -310,8 +312,9 @@ test('auth key not found', function (t) {
     rawRequest(opts, function (err, _, __, obj) {
         t.ok(err);
         t.equal(err.statusCode, 403);
-        t.equal(err.restCode, 'KeyDoesNotExist');
+        t.equal(err.restCode, 'InvalidCredentials');
         t.ok(err.message);
+        t.strictEqual(err.message, this.firstCredError);
         t.end();
     });
 });
@@ -327,8 +330,9 @@ test('signature invalid', function (t) {
     rawRequest(opts, function (err, _, __, obj) {
         t.ok(err);
         t.equal(err.statusCode, 403);
-        t.equal(err.restCode, 'InvalidSignature');
+        t.equal(err.restCode, 'InvalidCredentials');
         t.ok(err.message);
+        t.strictEqual(err.message, this.firstCredError);
         t.end();
     });
 });
@@ -416,7 +420,7 @@ test('presigned URL invalid signature', function (t) {
         rawRequest(path, function (err2, req, res, obj) {
             t.ok(err2);
             t.equal(res.statusCode, 403);
-            t.equal(obj.code, 'InvalidSignature');
+            t.equal(obj.code, 'InvalidCredentials');
             t.ok(obj.message);
             t.end();
         });
@@ -578,6 +582,49 @@ test('access unapproved and operator /public', function (t) { // MANTA-2214
     });
 });
 
+test('nonexistent user fake /public', function (t) {
+    this.client.get('/nonexistentuseraaa/public', function (err, stream, res) {
+        t.ifError(err);
+        t.ok(stream);
+        t.equal(res.statusCode, 200);
+        if (stream) {
+            stream.once('end', t.end.bind(t));
+            stream.resume();
+        } else {
+            t.end();
+        }
+    });
+});
+
+test('nonexistent user fake /public/thing', function (t) {
+    var opts = {
+        path: '/nonexistentuseraaa/public/thing',
+        headers: {
+        }
+    };
+    rawRequest(opts, function (err, _, __, obj) {
+        t.ok(err);
+        t.equal(err.statusCode, 404);
+        t.equal(err.restCode, 'ResourceNotFound');
+        t.ok(err.message);
+        t.end();
+    });
+});
+
+test('nonexistent user stor 403', function (t) {
+    var opts = {
+        path: '/nonexistentuseraaa/stor',
+        headers: {
+        }
+    };
+    rawRequest(opts, function (err, _, __, obj) {
+        t.ok(err);
+        t.equal(err.statusCode, 403);
+        t.equal(err.restCode, 'AuthorizationFailed');
+        t.ok(err.message);
+        t.end();
+    });
+});
 
 test('create auth token 403 (fails if MANTA_USER is operator)',
         function (t) {


### PR DESCRIPTION
MANTA-3356 prevent user and key enumeration through muskie


This PR was migrated-from-gerrit, <https://cr.joyent.us/#/c/2246/>.
The raw archive of this CR is [here](https://github.com/joyent/gerrit-migration/tree/master/archive/2246).
See [MANTA-4594](https://smartos.org/bugview/MANTA-4594) for info on Joyent Eng's migration from Gerrit.

## CR discussion

##### @davepacheco commented at 2017-07-24T22:06:01

> Patch Set 2:
> 
> This looks good, though I'd like another pair of eyes if somebody is available, since this could conceivably be a breaking change.
> 
> For ourselves, I think it would be useful to enumerate in the ticket the error codes being removed by this change.  Have you checked whether anything in Manta or node-manta depends on those error codes?  I have a bad feeling they might, and if so, I'm not sure how to evolve this.
> 
> Do we think it's possible that customers might be relying on these codes (and is there anything we could do about it if so)?

##### @arekinath commented at 2017-07-24T23:00:27

> Patch Set 2:
> 
> I've added a comment to the bug enumerating all the changed error codes and conditions. I've also been grepping around in the manta Github repositories for references to these codes and haven't found any non-trivial ones yet outside of auto-tests (e.g. two of the marlin auto-tests need fixing up)

##### @arekinath commented at 2017-07-24T23:19:07

> Patch Set 2:
> 
> This really is a breaking/major change, mucking about with the error codes (and introducing a new one).
> 
> FWIW I think the errors in question though are not really ones that have a useful automated response on the part of clients. The only one that might is UserNotFound (since there actually is an API for creating new sub-users that you could conceivably go call in response). The others are only really reasonable to respond to by throwing the error up to a human.

##### @jordanhendricks commented at 2017-07-25T15:33:16

> Patch Set 2:
> 
> (5 comments)
> 
> This looks good. Thanks for noticing this and fixing it!
> 
> Could you paste a sample log entry with the new output in the ticket? 
> 
> Also, we should update the muskie API docs to match the new errors. Is there a ticket filed for that?

##### @arekinath commented at 2017-07-25T17:28:59

> Patch Set 2:
> 
> (5 comments)

##### Patch Set 2 code comments

> ###### lib/auth.js#716 @jordanhendricks  
> 
> > Is this the same regex exported in common.js? It has the same name. If that's the case, we should use the commonized version, or name it something different to distinguish it from the already exported regex.
> 
> ###### lib/auth.js#716 @arekinath  
> 
> > No, the one in common.js is PUBLIC_STOR_PATH, and matches a path *under* the public directory. This one is PUBLIC_STOR_ROOT and matches only the root of the public tree. They already have different names.
> 
> ###### lib/auth.js#716 @jordanhendricks  
> 
> > Ah, sorry. In that case, could we move this to the top of the file since it's a global?
> 
> ###### lib/auth.js#716 @arekinath  
> 
> > Ok, moved.
> 
> ###### lib/auth.js#734 @jordanhendricks  
> 
> > I know this isn't your change, but could we move this log statement to the actual loadOwner() handler (or update it to have the correct function)? It seems like it got left behind when I abstracted this code out for MPU.
> 
> ###### lib/auth.js#734 @arekinath  
> 
> > Sure.
> 
> ###### lib/auth.js#756 @jordanhendricks  
> 
> > I'm not sure I understand the logic here (I find code evaluating output from mahi a bit difficult to follow). Why wouldn't req.caller.user or req.caller.account.login be defined?
> 
> ###### lib/auth.js#756 @arekinath  
> 
> > req.caller.user is defined if we're using a sub-user (RBAC). If we're authenticated as just a normal account, it's not defined, and we run this branch (using the account login).
> > 
> > If it is defined, we use account.login + '/' + user.login. This is the same logic from further down in this file (though taking anon access into account here too)
> 
> ###### lib/auth.js#769 @jordanhendricks  
> 
> > What happens for a non-readonly request (e.g., a PUT)?
> > 
> > Also, isn't this the same check performed by HttpRequest.isPublicGet()?
> 
> ###### lib/auth.js#769 @arekinath  
> 
> > No, isPublicGet() evauates against PUBLIC_STOR_PATH, not PUBLIC_STOR_ROOT.
> > 
> > A PUT here falls through down to the AuthorizationError below, which is the same result it would produce for a real account.
> 
> ###### lib/auth.js#769 @jordanhendricks  
> 
> > That makes more sense now that I see they are actually different. Thanks.
> 
> ###### test/auth.test.js#585 @jordanhendricks  
> 
> > Check the response code here?
> 
> ###### test/auth.test.js#585 @arekinath  
> 
> > Done

##### @jordanhendricks commented at 2017-07-25T17:44:35

> Patch Set 3: Code-Review+1
> 
> (2 comments)

##### @davepacheco commented at 2017-07-25T18:35:58

> Patch Set 3: Code-Review+1

##### @arekinath commented at 2017-08-03T18:58:58

> Patch Set 2:
> 
> (1 comment)

##### @davepacheco commented at 2017-08-03T19:40:17

> Patch Set 4: Code-Review+1

##### @kellymclaughlin commented at 2017-10-13T22:32:01

> Patch Set 4:
> 
> This change will break the java client tests (https://github.com/joyent/java-manta/blob/master/java-manta-it/src/test/java/com/joyent/manta/client/MantaClientErrorIT.java#L63-L88) and it does expose some of error codes changed here like AccountDoesNotExist (https://github.com/joyent/java-manta/blob/master/java-manta-client-unshaded/src/main/java/com/joyent/manta/exception/MantaErrorCode.java#L27). Given that it is possible the Samsung may be relying on the current responses. Is there an established way to handle these situations to check if this change would affect their code?

##### @kellymclaughlin commented at 2017-10-27T22:37:05

> Patch Set 4:
> 
> There are 28 failures with MPU tests in the muskie test suite with this change. The failures can be resolved with two small changes:
> 
> Add res as the third argument to the call to loadOwnerFromPath here: https://github.com/joyent/manta-muskie/blob/master/lib/uploads/commit.js#L136
> 
> s/AccountDoesNotExistError/AuthorizationFailedError here: https://github.com/joyent/manta-muskie/blob/master/test/mpu/commit.test.js#L651