### PR TITLE
MANTA-3220 MPU shark selection should try to connect to several sets of sharks

### DIFF
--- a/lib/uploads/create.js
+++ b/lib/uploads/create.js
@@ -16,6 +16,7 @@ var path = require('path');
 var restify = require('restify');
 var util = require('util');
 var verror = require('verror');
+var vasync = require('vasync');
 
 var auth = require('../auth');
 var common = require('../common');
@@ -32,6 +33,107 @@ var sprintf = util.format;
 
 ///--- Helpers
 
+
+/*
+ * Attempts to grab a running pool for a given shark from cueball
+ * to ensure that muskie had a recent active connection to the
+ * shark. If it didn't, one will be created with the cueball
+ * createPool api method. This function is used in chooseSharks to
+ * pick an appropriate shark for a new mpu-create operation.
+ */
+function ensureSharkHasPool(req, shark, callback) {
+    var host = shark.manta_storage_id;
+
+    var sharkInfo = {
+        shark: host,            // hostname of the shark
+        result: null,           // 'ok' or 'fail'
+        timeTotal: null,        // time spent deciding whether to use a shark
+        _startTime: Date.now(), // decision start time
+        error: null             // error encounter if connection failed
+    };
+
+    var pool = req.sharkAgent.getPool(host);
+    if (pool) {
+        req.log.debug({
+            shark: shark,
+            pool: pool.getState()
+        }, 'ensureSharkHasPool: got existing pool');
+    } else {
+        req.sharkAgent.createPool(host);
+        pool = req.sharkAgent.getPool(host);
+        req.log.debug({
+            shark: shark,
+            pool: pool.getState()
+        }, 'ensureSharkHasPool: created pool for shark');
+    }
+
+    req.sharksContacted.push(sharkInfo);
+
+    if (pool.isInState('running')) {
+        sharkInfo.result = 'ok';
+        sharkInfo.timeTotal = Date.now() - sharkInfo._startTime;
+        setImmediate(callback, null, shark);
+    } else if (pool.isInState('starting') || pool.isInState('failed')) {
+        var timedOut = false;
+        var sharkTimeout = setTimeout(function () {
+            timedOut = true;
+            req.log.debug({
+                shark: shark,
+                state: pool.getState()
+            }, 'ensureSharkHasPool: pool state change timeout');
+            sharkInfo.result = 'fail';
+            sharkInfo.timeTotal = Date.now() - sharkInfo._startTime;
+            sharkInfo.error = new Error('timed out waiting for shark pool ' +
+                'state change.');
+            callback();
+        }, req.sharkConfig.connectTimeout);
+
+        function onStateChanged(st) {
+            if (timedOut) {
+                return;
+            }
+            req.log.debug({
+                shark: shark,
+                state: st
+            }, 'ensureSharkHasPool: pool state changed');
+            if (st === 'running') {
+                clearTimeout(sharkTimeout);
+                sharkInfo.result = 'ok';
+                sharkInfo.timeTotal = Date.now() - sharkInfo._startTime;
+                callback(null, shark);
+            } else if (st === 'starting' || st === 'failed') {
+                // According to the cueball api docs, it is possible for a pool
+                // in the 'failed' state to recover a connection one of it's
+                // backends and transition back into the 'running' state.
+                pool.once('stateChanged', onStateChanged);
+            } else {
+                assert.ok(st === 'stopped' || st === 'stopping');
+                req.log.debug({
+                    state: st
+                }, 'ensureSharkHasPool: pool in inactive state');
+                clearTimeout(sharkTimeout);
+                sharkInfo.result = 'fail';
+                sharkInfo.timeTotal = Date.now() - sharkInfo._startTime;
+                sharkInfo.error = new verror.VError('pool changed to an ' +
+                        'inactive state %s', st);
+                callback();
+            }
+        }
+        pool.once('stateChanged', onStateChanged);
+
+    } else {
+        // With this assertion, we guard against the case where the pool
+        // is in a state that is not documented in the cueball api docs.
+        assert.ok(pool.isInState('stopped') || pool.isInState('stopping'));
+        sharkInfo.result = 'fail';
+        sharkInfo.timeTotal = Date.now() - sharkInfo._startTime;
+        sharkInfo.error = new verror.VError('found shark pool in ' +
+            'terminal state: %s', pool.getState());
+        callback();
+    }
+}
+
+
 /*
  * Selects the sharks for the upload through the picker.choose interface.
  *
@@ -39,7 +141,7 @@ var sprintf = util.format;
  * the durability-level and the content-length headers, respectively, or
  * set to a default value.
  */
-function chooseSharks(req, size, copies, cb) {
+function chooseSharks(req, res, size, copies, cb) {
     assert.object(req, 'req');
     assert.number(size, 'size');
     assert.number(copies, 'copies');
@@ -55,14 +157,41 @@ function chooseSharks(req, size, copies, cb) {
             replicas: copies,
             size: size
         };
+
         req.picker.choose(opts, function (err, sharks) {
             if (err) {
                 cb(err);
             } else {
+                var funcs = [];
+
+                req._sharks = sharks;
                 log.debug({
-                    sharks: sharks[0]
-                }, 'upload: sharks chosen');
-                cb(null, sharks[0]);
+                    sharks: req._sharks
+                }, 'chooseSharks: entered');
+                req.sharksContacted = [];
+
+                function trySharks(sharkSet, callback) {
+                    vasync.forEachParallel({
+                        func: ensureSharkHasPool.bind(null, req),
+                        inputs: sharkSet
+                    }, callback);
+                }
+
+                sharks.forEach(function (sharkSet) {
+                    funcs.push(trySharks.bind(null, sharkSet));
+                });
+                vasync.tryEach(funcs, function (err2, results) {
+                    req.sharks = results.successes || [];
+                    if (req.sharks.length === 0) {
+                        cb(new SharksExhaustedError(res), null);
+                        return;
+                    }
+                    log.debug({
+                        attempted: req.sharksContacted,
+                        chosen: req.sharks
+                    }, 'chooseSharks: done');
+                    cb(null, req.sharks);
+                });
             }
         });
     }
@@ -287,7 +416,7 @@ function createUpload(req, res, next) {
     var s = req.upload.mpuSize;
     var c = req.upload.mpuCopies;
 
-    chooseSharks(req, s, c, function (err, sharks) {
+    chooseSharks(req, res, s, c, function (err, sharks) {
         if (err) {
             next(err);
         } else {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "backoff": "2.3.0",
         "bunyan": "0.22.1",
         "bunyan-syslog": "0.2.2",
-        "cueball": "2.2.9",
+        "cueball": "2.3.0",
         "dashdash": "1.3.2",
         "deep-equal": "0.0.0",
         "dtrace-provider": "0.2.8",
@@ -34,7 +34,7 @@
         "moray": "3.1.1",
         "once": "1.3.0",
         "restify": "2.6.3",
-        "vasync": "^1.5.0",
+        "vasync": "2.0.0",
         "verror": "^1.9.0",
         "watershed": "0.3.0",
         "xtend": "2.1.1"


### PR DESCRIPTION
MANTA-3220 MPU shark selection should try to connect to several sets of sharks


This PR was migrated-from-gerrit, <https://cr.joyent.us/#/c/2432/>.
The raw archive of this CR is [here](https://github.com/joyent/gerrit-migration/tree/master/archive/2432).
See [MANTA-4594](https://smartos.org/bugview/MANTA-4594) for info on Joyent Eng's migration from Gerrit.

## CR discussion

##### @jordanhendricks commented at 2017-08-21T18:51:51

> Patch Set 2:
> 
> (3 comments)

##### Patch Set 2 code comments

> ###### lib/uploads/create.js#0 @jordanhendricks  
> 
> > Was there also a cueball change associated with this?
> 
> ###### lib/uploads/create.js#65 @jordanhendricks  
> 
> > I think we probably want to leave this message at "debug" level. Same with the messages below. (By default, we log anything at level WARN or above.)
> 
> ###### lib/uploads/create.js#68 @jordanhendricks  
> 
> > I realize this is mostly drafted off of the code in lib/obj.js, but I've always found that code a bit hard to follow. For the sake of readability, what do you think of restructuring this to not use an immediately invoked function expression, and instead define the attempt() function first, then invoke it?

##### Patch Set 5 code comments

> ###### lib/uploads/create.js#44 @joyent-automation  
> 
> > warning: undeclared identifier: req
> 
> ###### lib/uploads/create.js#46 @joyent-automation  
> 
> > warning: undeclared identifier: req
> 
> ###### lib/uploads/create.js#49 @joyent-automation  
> 
> > warning: undeclared identifier: req
> 
> ###### lib/uploads/create.js#71 @joyent-automation  
> 
> > warning: undeclared identifier: req

##### @IanWyszynski commented at 2017-08-24T17:19:48

> Patch Set 6:
> 
> (2 comments)

##### @davepacheco commented at 2017-08-24T18:13:47

> Patch Set 6:
> 
> (8 comments)

##### @IanWyszynski commented at 2017-08-25T00:07:30

> Patch Set 6:
> 
> (4 comments)

##### @IanWyszynski commented at 2017-08-25T00:25:45

> Patch Set 6:
> 
> (1 comment)

##### @IanWyszynski commented at 2017-08-25T00:35:30

> Patch Set 6:
> 
> (1 comment)

##### @IanWyszynski commented at 2017-08-25T01:36:20

> Patch Set 6:
> 
> (1 comment)

##### Patch Set 6 code comments

> ###### lib/uploads/create.js#67 @IanWyszynski  
> 
> > Spoke to Alex Wilson about this: apparently invoking pool.claim will register as network activity with cueball which will double the time between subsequent keep-alive's for this particular shark. We agreed that checking the state of the running pool in this manner is preferable because it doesn't result in cueball state side effects.
> 
> ###### lib/uploads/create.js#67 @davepacheco  
> 
> > Are these pool states documented, committed interfaces from Cueball?
> 
> ###### lib/uploads/create.js#67 @IanWyszynski  
> 
> > They are the states that I got from a conversation with Alex but I didn't check against the docs and source. Having done so now, I don't see a 'waiting' state: https://joyent.github.io/node-cueball/#state_transitions. Given that we're either looking for a pool that has been connected for a long time, or we've just recently created one, it probably makes the most sense to:
> > 
> > - Accept 'running' pools
> > - Reject 'failed' pools
> > - Install a state-changed handler for pools that are in the 'starting' state and see if they eventually get to the 'running' state, at which point we have a connection to the shark.
> 
> ###### lib/uploads/create.js#67 @davepacheco  
> 
> > It would be nice to confirm that the states are a committed part of the cueball interface (i.e., that they're guaranteed not to change without a major version bump).
> 
> ###### lib/uploads/create.js#75 @davepacheco  
> 
> > What kind of errors can happen here?
> > 
> > How do we avoid catching a TypeError or other programmer error here?
> > 
> > Do we want to return here?
> 
> ###### lib/uploads/create.js#75 @IanWyszynski  
> 
> > The only error that can occur here is that cueball has found that there already exists a pool for the host. Alex said this was the behavior he wanted for the API. This kind of error shouldn't happen in this context, so I guess based on the error handling link you sent me, we shouldn't try/catch it but crash instead?
> 
> ###### lib/uploads/create.js#75 @davepacheco  
> 
> > Yeah, I think that's right.
> 
> ###### lib/uploads/create.js#78 @davepacheco  
> 
> > I imagine this belongs at L76?
> 
> ###### lib/uploads/create.js#78 @IanWyszynski  
> 
> > right.
> 
> ###### lib/uploads/create.js#82 @davepacheco  
> 
> > We generally try to make it so that a function is always synchronous or always asynchronous, not both.  There's a lot more information about this in the Node Error Handling Guidelines:
> > https://www.joyent.com/node-js/production/design/errors
> > 
> > I think you want to wrap these callback calls in a call to `setImmediate`.
> 
> ###### lib/uploads/create.js#86 @IanWyszynski  
> 
> > this callback call should not be here. I accidentally included it here from previous debugging. will remove it.
> 
> ###### lib/uploads/create.js#96 @davepacheco  
> 
> > It's idiomatic to leave out subsequent arguments when you're passing an Error to the callback.  (i.e., drop the "null").
> 
> ###### lib/uploads/create.js#101 @davepacheco  
> 
> > Do we want to do anything about the pool that's now half-created?
> 
> ###### lib/uploads/create.js#102 @davepacheco  
> 
> > It seems strange that we're invoking the callback multiple times in this case.  What are trying to do here?
> 
> ###### lib/uploads/create.js#102 @IanWyszynski  
> 
> > The callback should only be called once, see the above comment for why currently it's being called twice.
> 
> ###### lib/uploads/create.js#102 @IanWyszynski  
> 
> > I see now how it's called twice, will introduce a fix in the next patchset.
> 
> ###### lib/uploads/create.js#111 @davepacheco  
> 
> > This is all subjective, but: this code generally looks pretty similar to some of the existing code, which is obviously understandable, but think the existing code's structure is pretty muddled.  I think it would be better to separate the levels of abstraction:
> > 
> >   - try <operation> up to 3 times on different sets of arguments (analogous to vasync.tryEach, although that currently has a serious issue that we're in the process of resolving)
> >   - the existing forEachParallel
> >   - the tryShark operation
> > 
> > As it is now, these concerns are all intermixed in this 100 or so LOC.  (Again, I realize this structure mirrors existing code.)
> > 
> > I think it would also help if tryShark were a separate top-level function with a clear explanation of the "shark" argument and what values are passed to the callback.  It might help to call it something more explicit like ensureSharkHasPool().
> 
> ###### lib/uploads/create.js#111 @IanWyszynski  
> 
> > With regards to making tryShark, or ensureSharkHasPool a top level function, given the semantics of vasync.forEachParallel, I need to somehow bind the request argument 'req' to ensureSharHasPool so that I can access the agent and call the appropriate api functions. I tried doing a bind:
> > 
> > vasync.forEachParallel({
> >     func: ensureSharkHasPool.bind(req)
> >     ...
> > }
> > ...
> > 
> > But this doesn't bring the request object into scope as I thought it would. Do you have any suggestions for how I could accomplish this (accessing the request object in ensureSharkHasPool)?
> 
> ###### package.json#17 @IanWyszynski  
> 
> > This change depends on https://cr.joyent.us/#/c/2422/, I will update the package.json with the latest cueball version dependency once this other change is integrated.

##### @davepacheco commented at 2017-08-31T18:38:06

> Patch Set 6:
> 
> (9 comments)
> 
> Thanks for the changes.  I think the top-level function is a lot easier to understand now.

##### @IanWyszynski commented at 2017-09-01T19:45:39

> Patch Set 7:
> 
> (5 comments)

##### @IanWyszynski commented at 2017-09-01T20:45:41

> Patch Set 7:
> 
> (1 comment)

##### @IanWyszynski commented at 2017-09-01T21:01:09

> Patch Set 7:
> 
> (2 comments)

##### Patch Set 7 code comments

> ###### lib/uploads/create.js#39 @davepacheco  
> 
> > "ensure"?  This will work even if Muskie doesn't have a recent active connection, right?
> 
> ###### lib/uploads/create.js#39 @IanWyszynski  
> 
> > Yes
> 
> ###### lib/uploads/create.js#53 @davepacheco  
> 
> > Is there a falsey value we could get here other than `undefined`?  It seems like it would be clearer if this were just an "else" clause to the previous "if".
> 
> ###### lib/uploads/create.js#53 @IanWyszynski  
> 
> > We can only get an undefined here - I wrote the API method that does this and it's documented in the cueball api docs. However, I suppose that because this might change in the future, what you suggest makes sense. I think that because we have to do a createPool if the pool doesn't already exists, changing this check to if (!pool) { ... } might be a better fit.
> 
> ###### lib/uploads/create.js#75 @davepacheco  
> 
> > I'm not sure we actually do want to clean up the pool.  Sorry if my previous question was confusing, but I was really just trying to understand whether it was intentional.  I don't think it's a bad idea to leave the pool running, because it's likely we will eventually need it anyway.  I would probably add a comment either way explaining our rationale.
> 
> ###### lib/uploads/create.js#75 @IanWyszynski  
> 
> > Understood, yeah I think leaving the pool running is the way to go, cueball will handle failed pools (in the event that they fail during this operation).
> 
> ###### lib/uploads/create.js#78 @davepacheco  
> 
> > I believe setImmediate takes additional arguments, so that you can just do:
> > 
> >     setImmediate(callback, null, shark)
> 
> ###### lib/uploads/create.js#81 @davepacheco  
> 
> > I think this should probably be "once" so that this handler gets cleaned up (and we don't re-invoke this closure), perhaps hours later in response to some other state change.
> 
> ###### lib/uploads/create.js#81 @IanWyszynski  
> 
> > Oh, actually in testing I've seen that sometimes this event handler fires multiple times, when a pool is created, and it's not until some subsequent time that the state actually transitions to "running." So I think it order for this to work we do actually have to receive multiple callbacks for the event. However I do think that as soon as we see the pool in either the "running" or the "failed" state, then this listener should be removed.
> 
> ###### lib/uploads/create.js#86 @davepacheco  
> 
> > What case is `once` handling?
> 
> ###### lib/uploads/create.js#86 @IanWyszynski  
> 
> > It's preventing the callback in the pool's 'stateChanged' handler from being invoked after the callback is called once from the timeout handler already. Perhaps "once" is not the best name, maybe "guard"? The rationale for the timeout is that we don't want to spend too long waiting for a pool to come up if we can just try another shark on the list - the timeout is the same as that waited when contact a shark during object upload.
> 
> ###### lib/uploads/create.js#86 @IanWyszynski  
> 
> > I am realizing now that the a possible solution is to use pool.once, but to do so within a function that will reset itself as a listener for the 'stateChanged' event if it finds that the pool is in the 'starting' state. That way, if the pool failed, it's running, or we timed out, no further callbacks will be scheduled, but if we keep listening for a state change while the pool is starting up.
> 
> ###### lib/uploads/create.js#95 @davepacheco  
> 
> > If the goal is to have the timeout not run if we've successfully transitioned to running, it's usually better to use `clearTimeout` to remove the timeout in the success case.
> 
> ###### lib/uploads/create.js#95 @IanWyszynski  
> 
> > Is there an analogous function for removing the pool's stateChanged handler above?
> 
> ###### lib/uploads/create.js#95 @IanWyszynski  
> 
> > Nevermind. Got around this - see comment above.

##### @IanWyszynski commented at 2017-09-09T00:05:03

> Patch Set 9:
> 
> I have updated the testing notes for the latest patch set of this change.

##### @davepacheco commented at 2017-09-12T21:58:41

> Patch Set 10:
> 
> (5 comments)
> 
> Thanks.

##### @IanWyszynski commented at 2017-09-13T17:19:01

> Patch Set 10:
> 
> (5 comments)

##### @IanWyszynski commented at 2017-09-13T19:25:46

> Patch Set 10:
> 
> (1 comment)

##### Patch Set 10 code comments

> ###### lib/uploads/create.js#54 @davepacheco  
> 
> > Can we make this an `else` to make clearer that exactly one of the previous block or the subsequent block will run?
> 
> ###### lib/uploads/create.js#54 @IanWyszynski  
> 
> > I see. WIll do.
> 
> ###### lib/uploads/create.js#90 @davepacheco  
> 
> > Is it intentional that we reset the timer in this case?
> 
> ###### lib/uploads/create.js#90 @IanWyszynski  
> 
> > Yes - I think I mentioned this in a previous comment, but I observed that for a newly created pool, the pool can emit a 'stateChanged', reporting that the pool is in state "starting" many times before the "running" state is reported. The timer is reset here so that while we're receiving such callbacks (before the timeout), we keep accepting observing state changes.
> 
> ###### lib/uploads/create.js#90 @davepacheco  
> 
> > It makes sense that you would re-add the listener.  But I don't know about resetting the timeout.  Doesn't that mean that if the timeout was, say, 2 seconds, this operation could go on forever, as long as the state kept changing every 2 seconds?
> 
> ###### lib/uploads/create.js#90 @IanWyszynski  
> 
> > Ah! This didn't register the first time I read it. Thanks for pointing this out.
> 
> ###### lib/uploads/create.js#99 @davepacheco  
> 
> > I think this case should probably be an assertion failure.
> 
> ###### lib/uploads/create.js#99 @IanWyszynski  
> 
> > Will do
> 
> ###### lib/uploads/create.js#99 @IanWyszynski  
> 
> > Actually, I'm not sure it should be - I think it's technically possible that we create the pool but then before we observe it's state it has already failed. This is not a programmer error but indicates a problem with the connection to the shark.
> 
> ###### lib/uploads/create.js#99 @davepacheco  
> 
> > In that case, assert that the only way to get here is if the state is `failed`?
> > 
> > I want to make sure if some new state is added that we aren't considering now, the program crashes rather than proceeding.
> 
> ###### lib/uploads/create.js#99 @IanWyszynski  
> 
> > I see. I could turn this into a branch for state === failed and crash if we find that the pool is in not in any of the states we expect it to be in.
> 
> ###### lib/uploads/create.js#144 @davepacheco  
> 
> > Why would `err2` be falsey but `results.successes.length` would be less than `copies`?
> > 
> > I think you could replace a lot of this with the recently-added `vasync.tryEach`, although there's an outstanding fix to that that may be necessary to upgrade here.
> 
> ###### lib/uploads/create.js#144 @IanWyszynski  
> 
> > You're right - I think it should just be an error check. I'll look into the vasync.tryEach fix.
> 
> ###### lib/uploads/create.js#157 @davepacheco  
> 
> > I think we probably would want to combine these log messages.
> > 
> > I also think they shouldn't be info-level, as we wouldn't want these in the normal log output.
> 
> ###### lib/uploads/create.js#157 @IanWyszynski  
> 
> > Will do.

##### Patch Set 11 code comments

> ###### lib/uploads/create.js#147 @joyent-automation  
> 
> > warning: identifer err hides an identifier in a parent scope

##### @davepacheco commented at 2017-09-14T21:56:56

> Patch Set 10:
> 
> (3 comments)
> 
> Thanks -- I think this is a lot cleaner with `tryEach`.

##### @IanWyszynski commented at 2017-09-15T21:05:05

> Patch Set 12:
> 
> (2 comments)

##### Patch Set 12 code comments

> ###### lib/uploads/create.js#137 @davepacheco  
> 
> > This is really a list of sharks, right?  Not one shark?
> 
> ###### lib/uploads/create.js#137 @IanWyszynski  
> 
> > Right

##### @IanWyszynski commented at 2017-09-23T00:49:25

> Patch Set 14:
> 
> (1 comment)
> 
> I have added testing notes that cover the major cases that result in this diff being invoked. Would appreciate if either of you could take a look at this for CR and/or IA! Thanks to both of you for helping me with this change!

##### @davepacheco commented at 2017-09-28T22:55:28

> Patch Set 12:
> 
> (3 comments)

##### Patch Set 14 code comments

> ###### lib/uploads/create.js#93 @davepacheco  
> 
> > What if the new state is none of 'running', 'starting', or 'failed'?  It seems like we'll ignore it, then wait for the timeout and fail the request.
> 
> ###### lib/uploads/create.js#98 @davepacheco  
> 
> > This has to be a VError to use the '%s' behavior.
> > 
> > Also, is there a case where we would actually expect this.  (I can't remember if we talked about this before.)  If we don't ever call pool.stop() in Muskie, I think it would be fine to assert that we never get to this point (with a comment explaining that).
> 
> ###### lib/uploads/create.js#98 @IanWyszynski  
> 
> > We could get an existing pool that is in the stopped state. I think we should handle it because it is documented as one of the possible states of a pool in the cueball docs.
> 
> ###### lib/uploads/create.js#101 @davepacheco  
> 
> > It should be impossible for the pool to be in state 'running', 'starting', or 'failed', shouldn't it?
> 
> ###### lib/uploads/create.js#101 @IanWyszynski  
> 
> > I thought that this was the pattern that you suggested in the

##### @davepacheco commented at 2017-10-04T23:17:38

> Patch Set 16:
> 
> (4 comments)
> 
> This is looking good.  I noticed a few more things as I look at this with fresher eyes.

##### @IanWyszynski commented at 2017-10-07T01:06:44

> Patch Set 16:
> 
> (6 comments)

##### Patch Set 16 code comments

> ###### lib/uploads/create.js#53 @davepacheco  
> 
> > Would it be more consistent to use "host" here?
> 
> ###### lib/uploads/create.js#53 @IanWyszynski  
> 
> > yup - will modify.
> 
> ###### lib/uploads/create.js#109 @davepacheco  
> 
> > I think you want to wrap this in a `setImmediate` like at L62.
> 
> ###### lib/uploads/create.js#109 @IanWyszynski  
> 
> > I'll do this for the next patchset, but depending on what we decide to do about errors in this function (log or pass to callback -- referencing my response to your third comment) we may end up just logging the error and issuing the callback directly.
> 
> ###### lib/uploads/create.js#143 @davepacheco  
> 
> > I believe we keep track of this array for normal requests and we hang it off the request (as `request.sharks`).  At the end of the request, we include this in the log message.  That way, from the final log entry, we can see which sharks we talked to.  Are we doing that here?
> 
> ###### lib/uploads/create.js#143 @IanWyszynski  
> 
> > Not currently. I will modify this to follow the convention though. Looking at the object code, it looks like the sharks returned from the picker are stored in `req._sharks`, the sharks that are contacted are stored in the `req.sharksContacted`, and the sharks that are ultimately chosen are stored in `req.sharks`.
> 
> ###### lib/uploads/create.js#143 @davepacheco  
> 
> > Yes, I think that's right, but I'm not sure what the precise semantics of each of these are.  For example, I think the picker returns a list of sets of sharks, while sharksContacted is a flat array.  I would expect "req.sharks" would be one of the sets.  So all three have slightly different forms.
> > 
> > If we decide to use sharksContacted here, and I think that does make sense, it would be good to match the form used for that field in regular PUT log entries.  You'll have to see if all of the same fields apply, though.
> 
> ###### lib/uploads/create.js#143 @IanWyszynski  
> 
> > In patchset 17, I've ensure that the semantics of these fields match those of regular object puts. req._sharks list of shark sets returned by the picker.  req.sharksContacted consists is a list of 'sharkInfo' objects that the process attempted to contact with fields: host, result, timeToFirstByte, timeTotal, and _startTime. For this context, timeToFirstByte does not make sense because we aren't streaming data to sharks here. I've adjusted req.sharksContacted to consist of sharkInfo objects with all but the timeToFirstByte field. Finally, the req.sharks field is the shark set that the decision procedure settled on.
> 
> ###### lib/uploads/create.js#158 @davepacheco  
> 
> > Does this need a `new`?
> > 
> > Usually you can leave off the `, null` argument.
> > 
> > Are we losing information about the cause (`err2`) here?
> 
> ###### lib/uploads/create.js#158 @IanWyszynski  
> 
> > Yes - I'm not sure how to return a SharksExhaustedError and preserve information about err2 though. Returning  SharksExhaustedError is consistent with the put object code. What I could do is explicitly log all errors in the trySharks function instead of returning them in the callback. That way any error returned here already appears in the logs and we can just rely on `results` to determine whether we found a shark set.
> 
> ###### lib/uploads/create.js#158 @davepacheco  
> 
> > In general, it's much easier if the final error preserves the cause information.  When you're scanning over the logs, and you have a 500 that you're investigating, it's quite a bit harder to walk back to find the log entry for the previous error for the same request.  The previous log entry might even be in a separate file if the error occurs across a log rotation boundary.
> > 
> > It doesn't look like the SharksExhaustedError supports a cause today, but it could (e.g., the way InternalError does).
> > 
> > We could also put the specific shark errors into sharksContacted entries.  I thought we did that for the PUT path today, but we don't seem to.
> 
> ###### lib/uploads/create.js#158 @IanWyszynski  
> 
> > Considering the potentially different nature of errors for different sharks, it seems that including the errors in the sharkInfo objects actually gives us more information here. I'm going to include this change in the next patchset.

##### @davepacheco commented at 2017-10-16T20:57:21

> Patch Set 17:
> 
> (2 comments)

##### @IanWyszynski commented at 2017-10-17T22:25:26

> Patch Set 17:
> 
> (2 comments)

##### @davepacheco commented at 2017-11-07T23:47:41

> Patch Set 18: Code-Review+1