### PR TITLE
MANTA-3591 muskie throttle doesn't enforce concurrency properly

### DIFF
--- a/etc/config.coal.json
+++ b/etc/config.coal.json
@@ -9,8 +9,9 @@
     },
     "throttle": {
         "enabled": false,
-        "concurrency": 50,
-        "queueTolerance": 25
+        "concurrency": 128,
+        "queueTolerance": 32,
+        "reapInterval": 5000
     },
     "maxObjectCopies": 6,
     "maxRequestAge": 600,

--- a/lib/server.js
+++ b/lib/server.js
@@ -216,6 +216,16 @@ function createServer(options, clients, name) {
     server.use(auth.checkIfPresigned);
     server.use(common.enforceSSLHandler(options));
 
+    if (options.throttle.enabled) {
+        options.throttle.log = options.log;
+        options.throttle.server = server;
+
+        server.throttle = throttle.createThrottle(options.throttle);
+        server.use(server.throttle.throttlePreHandler());
+        log.info('registered throttle \'pre\' handler');
+    }
+
+
     server.use(function ensureDependencies(req, res, next) {
         var ok = true;
         var errors = [];
@@ -250,11 +260,6 @@ function createServer(options, clients, name) {
         }
     });
 
-    if (options.throttle.enabled) {
-        options.throttle.log = options.log;
-        var throttleHandle = throttle.createThrottle(options.throttle);
-        server.use(throttle.throttleHandler(throttleHandle));
-    }
     server.use(auth.authenticationHandler({
         log: log,
         mahi: clients.mahi,
@@ -487,6 +492,13 @@ function createServer(options, clients, name) {
             req.resume();
         }
     });
+
+    if (options.throttle.enabled) {
+        server.on('uncaughtException', server.throttle.throttleAfterHandler());
+        server.on('after', server.throttle.throttleAfterHandler());
+        log.info('registered throttle \'after\' and \'uncaughtException\' ' +
+            'handlers');
+    }
 
     return (server);
 }

--- a/lib/throttle.js
+++ b/lib/throttle.js
@@ -11,7 +11,8 @@
 var assert = require('assert-plus');
 var bunyan = require('bunyan');
 var vasync = require('vasync');
-var uuid = require('node-uuid');
+var libuuid = require('libuuid');
+var once = require('once');
 var util = require('util');
 var mod_url = require('url');
 var fs = require('fs');
@@ -23,83 +24,77 @@ var VError = require('verror');
 require('./errors');
 
 /*
- * High Level Operation
+ * Request Throttling
  *
- * This module exports a 'wait' method, which serves as the entry point
- * to all throttling operations the module provides. Users of the module
- * simply call the 'wait' function in a request-processing code path,
- * passing in a callback representing the work required to handle the
- * request. Currently, 'req' and 'res' arguments are also supplied
- * because the throttle is plugged in as restify middleware in muskie.
- * Future iterations of this throttle will aim to be generic across all
- * communication protocols, requiring only an argumentless work function
- * as input.
+ * This module implements a coarse request throttle with a vasync worker
+ * queue. Requests enter the queue in throttlePreHandler, and are removed
+ * throttleAfterHandler. Between the time that a request is pushed into
+ * the queue and the time that its vasync callback is invoked, it will
+ * go through two stages.
  *
- * The operation of wait() can be summarized as follows:
- *  - If the number of queued requests exceeds 'queueTolerance' and
- *    the throttle is enabled, throttle the incoming request and
- *    return.
- *  - If the throttle is enabled, put the incoming request-processing
- *    function on the request queue. This will result in either the
- *    request callback being scheduled immediately or, if all slots
- *    are occupied, being put on the request queue.
- *  - If the throttle is disabled, simply call the request-processing
- *    work function.
+ * (1) A recently added request will be queued for dispatch. This means
+ *     the remainder of its restify handler chain is paused.
+ * (2) If the requestQueue has an open slot, the request will be dispatched,
+ *     resuming the remainder of its restify handler chain.
  *
- * Overview of Tunables and Tradeoffs
+ * The vasync work queue itself accepts a 'concurrency' parameter. This
+ * determines the number of requests that can be in stage (2). The throttle
+ * has an additional parameter: 'queueTolerance'. This determines the
+ * number of requests which are allowed to be in stage (1). While 'concurrency'
+ * is enforced by the vasync work queue logic, the 'queueTolerance' is enforced
+ * by the logic in this module.
  *
- * The following parameters are implemented as SAPI tunables. Muskie
- * restart is required for any tunable modification to take effect.
+ * Requests enter stage (1) because the throttlePreHandler is installed as
+ * a 'use' handler via the restify server API for each incoming request.
+ * Request enter stage (2) once the vasync queue finds a slot. A request leaves
+ * stage (2) in one of two ways:
  *
- * queueTolerance - the number of requests the throttle can queue before
- * it starts sending indications that requests have been throttled to
- * clients. There is one 'global' queue to which incoming request are
- * added if all 'concurrency' slots in a vasync queue are occupied.
+ * (1) The server emits either an 'after' or 'uncaughtException' event for
+ *     the request. Since the throttleAfterHandler is installed as a listener
+ *     for both of these events, the request's queue slot will be cleared once
+ *     its vasync callback is invoked.
  *
- * Higher 'queueTolerance' values make it less likely that the throttle
- * will reject incoming requests and will increase muskies memory footprint
- * during period of high load. Lower 'queueTolerance' values make it more
- * likely that muskie will reject incoming requests.
+ * (2) Muskie sends a response with res.send API without invoking the restify
+ *     `next` function in the last handler of the route and the request lies
+ *     dormant in the queue for a configurable time interval. At this point
+ *     the `_reapStaleRequests` method will find that a response has been
+ *     sent out for the request and invoke its vasync callback. The
+ *     'reapInterval' configuration parameter controls how frequently Muskie
+ *     checks for stale entries in the request queue.
  *
- * concurrency - the number of slots the request queue has for scheduling
- * request-handling worker callbacks concurrently. When all the slots are
- * filled, the throttle will queue up to 'queueTolerance' callbacks before
- * throttling requests.
+ * Throttle Parameter Tradeoffs
  *
- * Higher 'concurrency' values allow Manta to handle more requests
- * concurrently and also makes it less likely that requests will spend time in
- * the queue and/or be throttled. Lower 'concurrency' values restrict
- * the number of requests manta can handle at once and make it more likely
- * that requests will spend time in the queue and/or be throttled.
+ * Under load, a Muskie throttle with high concurrency and low queueTolerance
+ * will allow Muskie to process more requests at once while maintaining a lower
+ * memory footprint. Such a configuration should be used when CPU resources
+ * are not limited.
  *
- * To prevent dropping incoming traffic needlessly, it is recommended that
- * lower 'concurrency' values be accompanied by proportionally higher
- * 'queueTolerance' values. Higher 'concurrency' values will result in
- * more requests be handled concurrently, and thus fewer requests being
- * queued (assuming the same load as in the previous scenario). This is
- * effectively a CPU/memory trade-off.
+ * Under load, a Muskie throttle with low concurrency and high queue tolerance
+ * will limit the number of concurrency requests and potentially lead to longer
+ * queuing delays. Such a configuration can result in a lower Muskie CPU
+ * utilization at the cost of request latency.
  *
- * enabled - a boolean value describing whether the throttle should queue
- * and throttle requests as designed.
- *
- * If enabled is false, the throttle will invoke the request-processing
- * callback immediately. The operation of muskie with 'enabled' set to
- * false is identical to the operation of muskie prior to the change
- * introducing this throttle.
- *
- * If enabled is true, the throttle will queue and throttle requests as
- * necessary.
+ * Throttling is disabled by default.
  */
 
-// Used for nanosecond to second conversion
-const NANOSEC_PER_SEC = Math.pow(10, 9);
+/*
+ * Specifies how frequently the throttle should audit its map of all in-flight
+ * requests for requests that have been responded to but remain in the queue
+ * because of a missing call to `next` in a restify handler. See the comment
+ * above Throttle#_reapStaleRequests for more information. The larger this
+ * value is, the more likely the we are to build up requests that have had
+ * responses sent but are taking up space in the queue. Smaller values may
+ * result in more frequent unnecessary checks which will increase the CPU
+ * footprint of the Muskie process.
+ *
+ * Since _reapStaleRequests is trying to compensate for programmer error in
+ * Muskie, there is no correct value here. In experiments, 5 seconds was shown
+ * to catch at most 1 stale request per iteration.
+ */
+var DEFAULT_REAP_INTERVAL_MS = 5000;
 
 /*
- * The throttle object maintains all the state used by the throttle. This state
- * consists of the tunables described above in addition to dtrace probes that
- * help to describe the runtime operation of the throttle. Structuring the
- * throttle as an object allows us to potentially instantiate multiple
- * throttles for different communication abstractions in the same service.
+ * Constructor for the throttle which kicks off periodic request reaping.
  */
 function Throttle(options) {
     assert.number(options.concurrency, 'options.concurrency');
@@ -108,23 +103,29 @@ function Throttle(options) {
     assert.ok(options.log, 'options.log');
     assert.number(options.queueTolerance, 'options.queueTolerance');
     assert.ok(options.queueTolerance > 0, 'queueTolerance must be positive');
+    assert.object(options.server, 'restify server');
 
-    this.log = options.log.child({ component: 'throttle'}, true);
+    this.log = options.log.child({
+        component: 'Throttle'
+    });
 
-    this.dtp = dtrace.createDTraceProvider('muskie-throttle');
+    this.server = options.server;
+    this.requestMap = {};
+
+    this.dtp = dtrace.createDTraceProvider('Muskie-throttle');
     this.throttle_probes = {
-        // number of occupied slots, number of queued requests,
-        // request rate, url, method
-        request_throttled: this.dtp.addProbe('request_throttled', 'int', 'int',
-                'char *', 'char *'),
-        // number of occupied slots, number of queued requests
-        request_handled: this.dtp.addProbe('request_handled', 'int', 'int',
-                'char *', 'char *'),
+        // request id
+        request_throttled: this.dtp.addProbe('request_throttled', 'char *'),
+        // request id
+        request_handled: this.dtp.addProbe('request_handled', 'char *'),
+        // request id
+        request_reaped: this.dtp.addProbe('request_reaped', 'char *'),
         // request id
         queue_enter: this.dtp.addProbe('queue_enter', 'char *'),
         // request id
-        queue_leave: this.dtp.addProbe('queue_leave', 'char *')
-
+        queue_leave: this.dtp.addProbe('queue_leave', 'char *'),
+        // num queued, num in-flight
+        throttle_stats: this.dtp.addProbe('throttle_stats', 'int', 'int')
     };
     this.dtp.enable();
 
@@ -132,58 +133,212 @@ function Throttle(options) {
     this.concurrency = options.concurrency;
     this.queueTolerance = options.queueTolerance;
 
+    /*
+     * 'task' refers to a chain of restify handlers. 'callback' is a hook back
+     * into the vasync code that will be called once the request has been
+     * processed.
+     */
     this.requestQueue = vasync.queue(function (task, callback) {
         task(callback);
     }, this.concurrency);
+
+    this.reapInterval = options.reapInterval || DEFAULT_REAP_INTERVAL_MS;
+    this._reapStaleRequests();
 }
 
-Throttle.prototype.wait = function wait(req, res, next) {
-    var self = this;
+/*
+ * In the unfortunate event that a restify handler chain contains a handler that
+ * does not always properly invoke the restify `next` callback, the restify
+ * server will emit neither an `after` event nor an `uncaughtException`
+ * event for the request that was being serviced. Since the throttle listens for
+ * these events to determine when request handling is complete, such missing
+ * `next` calls can lead to leaked requests in the throttle.
+ *
+ * To guard against resource leaks caused by past and future programmer errors
+ * of this type, we periodically scan the throttle's request map and invoke the
+ * vasync callback for requests for which Muskie has already sent a response.
+ * Invoking this callback frees up a vasync queue slot, ensuring that these
+ * slots don't become occupied indefinitely by stale requests.
+ *
+ * This function schedules itself to be called every 'Throttle#reapInterval'
+ * milliseconds. It will do so for the lifetime of a Muskie process so long as
+ * the throttle is enabled.
+ */
+Throttle.prototype._reapStaleRequests = function reap() {
 
-    if (self.requestQueue.length() >= self.queueTolerance) {
-        self.throttle_probes.request_throttled.fire(function () {
-            return ([self.requestQueue.npending, self.requestQueue.length(),
-                req.url, req.method]);
-        });
-        /*
-         * Wrap the ThrottledError in a VError so that the relevant fields
-         * appear in the audit entry of the throttled request. We translate the
-         * error to its cause before sending the response, as we don't want to
-         * expose the queue length or the queue tolerance of the throttle to end
-         * users.
-         */
-        var state = {
-            queuedRequests: self.requestQueue.npending,
-            inFlightRequests: self.requestQueue.length()
-        };
-        var cfg = {
-            queueTolerance: self.queueTolerance,
-            concurrency: self.concurrency
-        };
-        next(new VError(new ThrottledError(), 'muskie throttled this ' +
-                    'request. observed: %j, configured with: %j', state,
-                    cfg));
-        return;
+    function hrtimeToMS(hrtime) {
+        return (hrtime[0]*1e3) + (hrtime[0]/1e6);
     }
 
-    var req_id = req.getId();
+    var self = this;
 
-    self.throttle_probes.queue_enter.fire(function () {
-        return ([req_id]);
+    self.log.debug({
+        numReqs: Object.keys(self.requestMap).length
+    }, 'checking for stale requests');
+
+    Object.keys(self.requestMap).forEach(function (key) {
+        var value = self.requestMap[key];
+
+        var req = value.req;
+        var res = value.res;
+        var queueCb = value.queueCb;
+
+        assert.object(req, 'req');
+        assert.object(req, 'res');
+        assert.func(queueCb, 'queueCb');
+
+        /*
+         * Flag set by node core when res.end() is invoked by restify.
+         */
+        if (res.finished) {
+            self.log.debug({
+                reqId: req.getId()
+            }, 'reaping stale request slot');
+
+            self.throttle_probes.request_reaped.fire(function () {
+                return ([req.getId()]);
+            });
+
+            delete (self.requestMap[key]);
+
+            queueCb();
+        }
     });
 
-    self.requestQueue.push(function (cb) {
-        self.throttle_probes.queue_leave.fire(function () {
-            return ([req_id]);
+    setTimeout(self._reapStaleRequests.bind(self), self.reapInterval);
+};
+
+
+/*
+ * Returns a restify handler function which pauses incoming request
+ * routes or throttles them if there are 'concurrency' requests already
+ * dispatched and 'queueTolerance' requests already waiting for those
+ * slots.
+ */
+Throttle.prototype.throttlePreHandler = function preHandler() {
+    var self = this;
+
+    function throttleWait(req, res, next) {
+        self.log.debug({
+            reqId: req.getId()
+        }, 'throttlePreHandler: enter');
+
+        req.throttle = {
+            reqId: libuuid.create()
+        };
+
+        if (self.requestQueue.length() >= self.queueTolerance) {
+            self.throttle_probes.request_throttled.fire(function () {
+                return ([req.getId()]);
+            });
+
+            next(new VError(new ThrottledError(), 'request %s throttled ' +
+                '(queued = %d, in-flight = %d)', req.getId(),
+                self.requestQueue.length(), self.requestQueue.npending));
+            return;
+        }
+
+        assert.ok(Object.keys(self.requestMap).length <= self.concurrency,
+                'fewer than concurrency callbacks');
+
+        self.throttle_probes.queue_enter.fire(function () {
+            return ([req.getId()]);
         });
-        next();
-        cb();
-    });
 
-    self.throttle_probes.request_handled.fire(function () {
-        return ([self.requestQueue.npending, self.requestQueue.length(),
-            req.url, req.method]);
-    });
+        function startRoute(cb) {
+            assert.ok(!self.requestMap[req.throttle.reqId],
+                'attempting to register throttle handler twice');
+
+            /*
+             * The callback 'cb' is wrapped in a 'once' because once a request
+             * enters the map, there are two ways it can leave:
+             *  (1) it is reaped from the request map
+             *  (2) it is deleted from the request map in a callback for
+             *  the restify server's 'after' or 'uncaughtException' event
+             */
+            self.requestMap[req.throttle.reqId] = {
+                req: req,
+                res: res,
+                queueCb: once(cb)
+            };
+
+            self.log.debug({
+                reqId: req.getId(),
+                numreqs: Object.keys(self.requestMap).length
+            }, 'throttle request map insert');
+
+            self.throttle_probes.queue_leave.fire(function () {
+                return ([req.getId()]);
+            });
+            next();
+        }
+
+        self.requestQueue.push(startRoute);
+
+        self.throttle_probes.throttle_stats.fire(function () {
+            return ([self.requestQueue.length(), self.requestQueue.npending]);
+        });
+
+        self.log.debug({
+            reqId: req.getId()
+        }, 'throttlePreHandler: done');
+    }
+
+    return (throttleWait);
+};
+
+/*
+ * Returns a function to be called when either the 'after' or
+ * 'uncaughException' event is emitted by the restify server. This
+ * function is responsible for cleaning up all metadata the throttle
+ * stores for a given request.
+ */
+Throttle.prototype.throttleAfterHandler = function afterHandler() {
+    var self = this;
+
+    function throttleClearQueueSlot(req, _) {
+        self.log.debug({
+            reqId: req.getId()
+        }, 'throttleAfterHandler: enter');
+
+        assert.object(req.throttle, 'req.throttle');
+        assert.string(req.throttle.reqId, 'req.throttle.reqId');
+
+        var value = self.requestMap[req.throttle.reqId];
+        if (!value) {
+            self.log.debug({
+                reqId: req.getId()
+            }, 'missing request map entry, assuming reaped');
+            return;
+        }
+
+        assert.object(value.req, 'value.req');
+        assert.object(value.res, 'value.res');
+        assert.func(value.queueCb, 'value.cb');
+
+        self.log.debug({
+            reqId: req.getId(),
+            numreqs: Object.keys(self.requestMap).length
+        }, 'throttle request map remove');
+
+        delete (self.requestMap[req.throttle.reqId]);
+
+        self.throttle_probes.request_handled.fire(function () {
+            return ([req.getId()]);
+        });
+
+        value.queueCb();
+
+        self.throttle_probes.throttle_stats.fire(function () {
+            return ([self.requestQueue.length(), self.requestQueue.npending]);
+        });
+
+        self.log.debug({
+            reqId: req.getId()
+        }, 'throttleAfterHandler: done');
+    }
+
+    return (throttleClearQueueSlot);
 };
 
 
@@ -193,13 +348,6 @@ module.exports = {
 
     createThrottle: function createThrottle(options) {
         return (new Throttle(options));
-    },
-
-    throttleHandler: function (throttle) {
-        function throttleRequest(req, res, next) {
-            throttle.wait(req, res, next);
-        }
-        return (throttleRequest);
     }
 
 };


### PR DESCRIPTION
MANTA-3591 muskie throttle doesn't enforce concurrency properly


This PR was migrated-from-gerrit, <https://cr.joyent.us/#/c/3567/>.
The raw archive of this CR is [here](https://github.com/joyent/gerrit-migration/tree/master/archive/3567).
See [MANTA-4594](https://smartos.org/bugview/MANTA-4594) for info on Joyent Eng's migration from Gerrit.

## CR discussion

##### @IanWyszynski commented at 2018-03-12T21:02:59

> Patch Set 7:
> 
> I've pushed a couple of patchsets after asking for review, sorry about that. PS7 is the latest one that I've tested and seems to work. I'm going to pause work on this pending review because I think it's in a good place as far as functionality is concerned.

##### @jordanhendricks commented at 2018-03-14T22:57:13

> Patch Set 7:
> 
> (14 comments)

##### Patch Set 7 code comments

> ###### bin/throttlestat.d#76 @jordanhendricks  
> 
> > nit: wrap here?
> 
> ###### lib/throttle.js#35 @jordanhendricks  
> 
> > Maybe a "recently added request"?
> 
> ###### lib/throttle.js#35 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#65 @jordanhendricks  
> 
> > Would it make sense to separate the following two paragraphs out with a header? Something like: "Throttle Parameter Tradeoffs"?
> 
> ###### lib/throttle.js#78 @jordanhendricks  
> 
> > I think this could probably use a comment, even if it's short, to explain what it is, any tradeoffs for larger or smaller intervals, and maybe even why 5 seconds is a reasonable value as default.
> 
> ###### lib/throttle.js#78 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#80 @jordanhendricks  
> 
> > I would recommend a function comment on this, mentioning at the least, that the constructor kicks off the first scheduling of request reaping.
> 
> ###### lib/throttle.js#80 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#87 @jordanhendricks  
> 
> > assert.object?
> 
> ###### lib/throttle.js#87 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#100 @jordanhendricks  
> 
> > This comment and the ones immediately below it need to be updated, I think.
> 
> ###### lib/throttle.js#100 @IanWyszynski  
> 
> > I'm not sure why. These all just pass the restify request id now. It seemed like a cleaner interface that allows clients to perform latency calculations and track queueing delays. 
> > 
> > The last probe is meant to provide the ground truth about what's in the queue at any given moment.
> 
> ###### lib/throttle.js#100 @jordanhendricks  
> 
> > It looks like the "// request id" comment was copy-pasted above each probe. Was it not intended to be different for each one?
> 
> ###### lib/throttle.js#100 @IanWyszynski  
> 
> > No, they're all the same now. Would you prefer to see a single comment indicating that the argument is the same for all them?
> 
> ###### lib/throttle.js#100 @jordanhendricks  
> 
> > That might be clearer, I think. Up to you.
> 
> ###### lib/throttle.js#118 @jordanhendricks  
> 
> > I'm not sure I understand what "request handling function" means here.
> 
> ###### lib/throttle.js#118 @IanWyszynski  
> 
> > It's a chain of restify handlers. I'll modify it to state that more explicitly.
> 
> ###### lib/throttle.js#118 @jordanhendricks  
> 
> > Thanks, the comment in PS 10 is a lot clearer.
> 
> ###### lib/throttle.js#131 @jordanhendricks  
> 
> > I think the core of the problem here is not that we don't know whether muskie routes invoke next() correctly -- that is something that could in theory be verified, I think.
> > 
> > The deeper problem is that in the event that such a situation does happen, due to programmer error now or in the future, we don't want the request to be queued indefinitely or removed from the queue early.
> 
> ###### lib/throttle.js#131 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#138 @jordanhendricks  
> 
> > It would be good to document in the function comment that this function schedules itself on an interval, too.
> 
> ###### lib/throttle.js#138 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#147 @jordanhendricks  
> 
> > nit: camel case instead? ("numReqs")
> 
> ###### lib/throttle.js#147 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#157 @jordanhendricks  
> 
> > Is this flag set by restify?
> 
> ###### lib/throttle.js#157 @IanWyszynski  
> 
> > It is actually set on http.OutgoingMessage (which http.ServerResponse inherits from) by nodes core when req.end() is called by restify. req.end() is always called as a result of res.send().
> 
> ###### lib/throttle.js#157 @jordanhendricks  
> 
> > Ah. It might be good to explain that it is set by the node core then? My first instinct was to look through the muskie source to see where it was set, and I couldn't find it.
> 
> ###### lib/throttle.js#157 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#220 @jordanhendricks  
> 
> > Thanks for this comment. I've often seen "once" used to paper over incorrect code, so I was stoked to find an explanation as to why it was needed. It seems like this is a reasonable use of it.
> > 
> > nit: I would say "the request was reaped from the queue" instead of giving function name for (1), since that describes what happened, and isn't tied to the name of the function as it is today in code.
> 
> ###### lib/throttle.js#220 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#266 @jordanhendricks  
> 
> > When could this condition happen?
> 
> ###### lib/throttle.js#266 @IanWyszynski  
> 
> > It shouldn't, I'll turn this into an assertion.

##### @IanWyszynski commented at 2018-03-15T18:34:18

> Patch Set 8:
> 
> (12 comments)

##### @jordanhendricks commented at 2018-03-15T18:39:52

> Patch Set 9:
> 
> (2 comments)

##### @IanWyszynski commented at 2018-03-15T20:53:23

> Patch Set 10:
> 
> (2 comments)

##### @jordanhendricks commented at 2018-03-16T20:55:25

> Patch Set 10:
> 
> (9 comments)

##### Patch Set 10 code comments

> ###### lib/throttle.js#80 @jordanhendricks  
> 
> > Thanks for adding this.
> 
> ###### lib/throttle.js#83 @jordanhendricks  
> 
> > Is this the only reason we know of that this could happen?
> 
> ###### lib/throttle.js#83 @IanWyszynski  
> 
> > As far as I know the only way that neither the 'after' nor 'uncaughtException' event are emitted for a request is when a route is missing a call to 'next.' All correctly implemented routes should call next in each handler either with an error or no arguments. 
> > 
> > It's not actually directly stated in the docs, but I'm basing this off my reading of the source in addition to various github issue discussions:
> > 
> > https://github.com/restify/node-restify/issues/1585
> > https://github.com/restify/node-restify/issues/416
> > https://github.com/restify/node-restify/issues/201
> > 
> > The restify documentation reads "The handler chain for a route has been fully completed."
> 
> ###### lib/throttle.js#87 @jordanhendricks  
> 
> > and tie up CPU, presumably?
> 
> ###### lib/throttle.js#87 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#149 @jordanhendricks  
> 
> > Sorry to be so nitty on this, but I'm not sure Muskie is any more prone to programmer error than any other restify consumer, so I don't think it's really fair to dog on it.
> > 
> > How about something like: "In the unfortunate event that a restify handler chain contains a handler that does not always properly invoke the restify `next` callback, the restify server will not emit an `after` event nor an `uncaughtException` event for that request. Listening only for these events can potentially lead to leaked requests in the throttle."
> 
> ###### lib/throttle.js#149 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#156 @jordanhendricks  
> 
> > "throttle's"
> 
> ###### lib/throttle.js#156 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#157 @jordanhendricks  
> 
> > maybe just: "for"?
> 
> ###### lib/throttle.js#157 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#249 @jordanhendricks  
> 
> > "server's"
> 
> ###### lib/throttle.js#249 @IanWyszynski  
> 
> > Done

##### @IanWyszynski commented at 2018-03-19T17:26:54

> Patch Set 11:
> 
> (6 comments)

##### @jordanhendricks commented at 2018-03-19T22:30:13

> Patch Set 11: Code-Review+1
> 
> (14 comments)
> 
> Most of my comments are pretty minor this time around.

##### @IanWyszynski commented at 2018-03-20T01:17:49

> Patch Set 11:
> 
> (12 comments)

##### Patch Set 11 code comments

> ###### README.md#271 @jordanhendricks  
> 
> > Most tools I've seen like this will run for a single invocation and exit if no interval is given. Does throttlestat.d do that?
> 
> ###### README.md#271 @IanWyszynski  
> 
> > In the last patchset I actually changed the tool not to take an argument and instead generate the report every second. I forgot to update the documentation.
> 
> ###### bin/throttlestat.d#70 @jordanhendricks  
> 
> > Can this be wrapped?
> 
> ###### bin/throttlestat.d#70 @IanWyszynski  
> 
> > Done
> 
> ###### lib/server.js#220 @jordanhendricks  
> 
> > Does this handler show up in `req.timers` of the audit entry? (Just curious.)
> 
> ###### lib/throttle.js#53 @jordanhendricks  
> 
> > This is ambiguous, as the previous sentence is referring to a different request. It may be worth saying something like "a request already in stage 2" to indicate we are talking about a different request than the previous paragraph.
> 
> ###### lib/throttle.js#53 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#54 @jordanhendricks  
> 
> > "request's"
> 
> ###### lib/throttle.js#54 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#60 @jordanhendricks  
> 
> > "method"?
> 
> ###### lib/throttle.js#60 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#61 @jordanhendricks  
> 
> > I'm pretty sure this should be "invoke" here, right? (As this process invokes the callback; it does not already find that the vasync callback has been invoked)
> 
> ###### lib/throttle.js#61 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#62 @jordanhendricks  
> 
> > "Muskie" (same for other places in this file)
> 
> ###### lib/throttle.js#62 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#90 @jordanhendricks  
> 
> > s/for what is currently/for
> 
> ###### lib/throttle.js#90 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#152 @jordanhendricks  
> 
> > Looking at the docs, I noticed that the server can emit a "restifyError" as well. Should we address that error in any of the comments in this file?
> 
> ###### lib/throttle.js#152 @IanWyszynski  
> 
> > Based on the documentation here: http://restify.com/docs/4to5/ (the fact that a migration guide says "restify now emits a generic error" along with the fact that the 'restifyError' symbol doesn't exist in v2.6.3 (used by Muskie) it seems that this an event that we won't see in Muskie.
> 
> ###### lib/throttle.js#152 @jordanhendricks  
> 
> > Thanks for looking into that.
> 
> ###### lib/throttle.js#184 @jordanhendricks  
> 
> > Should we assert these values exist and are the proper types?
> 
> ###### lib/throttle.js#184 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#222 @jordanhendricks  
> 
> > The top-level request object for Muskie is cluttered with values that Muskie, node and restify code (and possibly other modules) have stored on it, making it hard to parse in debugging. If possible, it might be worth storing all throttle-related values under a new object (e.g., "req.throttle"). If it's too annoying to change, that's okay. Still, I generally try to avoid cluttering up the namespace on the object any further than it already is.
> 
> ###### lib/throttle.js#222 @IanWyszynski  
> 
> > I can add it to it's own object!
> 
> ###### lib/throttle.js#222 @jordanhendricks  
> 
> > Thanks for doing that. I think it makes it a lot easier to find where these values are set when debugging.
> 
> ###### lib/throttle.js#256 @jordanhendricks  
> 
> > Would it be worth calling this "queueCb" or something similar? It would be nice if it were immediately clear that this is related to the vasync queue (and not, for instance, the next() call in the request's handler chain).
> 
> ###### lib/throttle.js#256 @IanWyszynski  
> 
> > Done
> 
> ###### lib/throttle.js#303 @jordanhendricks  
> 
> > "reqId"? (same for other places in this file)

##### @jordanhendricks commented at 2018-03-20T16:36:51

> Patch Set 12: Code-Review+1
> 
> (2 comments)

##### @jordanhendricks commented at 2018-03-22T22:30:44

> Patch Set 13: Code-Review+1

##### @IanWyszynski commented at 2018-03-23T01:48:04

> Patch Set 14:
> 
> updated the name of the function returned from throttlePreHandler to 'throttleWait' so it's more obvious what the purpose is in 'req.timers'.

##### @jordanhendricks commented at 2018-03-23T02:10:53

> Patch Set 14: Code-Review+1

##### @IanWyszynski commented at 2018-11-20T22:10:29

> Patch Set 15: Patch Set 14 was rebased