### PR TITLE
MANTA-3779 Add 'singlePath' field to new object metadata

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -315,7 +315,11 @@ function auditLogger(options) {
              */
             if (owner) {
                 common.checkAccountSnaplinksEnabled(req, owner,
-                    function (enabled) {
+                    function (snaplinksEnabled) {
+                    var isSinglePathDelete = md.hasOwnProperty('singlePath') ?
+                        md.singlePath : false;
+                    var isAcceleratedDelete = !snaplinksEnabled ||
+                        isSinglePathDelete;
                     /*
                      * The intent of 'deleted_data_counter' is to count only
                      * deletes that unlink object backing files from storage
@@ -326,7 +330,7 @@ function auditLogger(options) {
                     if (md.type === 'object' && md.contentLength > 0) {
                         var storage = md.contentLength * md.sharks.length;
                         labels = {
-                            accelerated_gc: !enabled,
+                            accelerated_gc: isAcceleratedDelete,
                             owner: owner
                         };
                         deleted_data_counter.add(storage, labels);

--- a/lib/common.js
+++ b/lib/common.js
@@ -248,6 +248,7 @@ function createMetadata(req, type, cb) {
         } else { // Take from the prev is for things like mchattr
             md.sharks = (prev.sharks || []);
         }
+        md.singlePath = (req.accel_gc.singlePathEnabled) ? true : undefined;
         break;
 
     default:
@@ -334,8 +335,9 @@ function ensureEntryExists(req, res, next) {
  * are enabled.
  */
 function checkAccountSnaplinksEnabled(req, uuid, next) {
-    for (var i = 0; i < req.accountsSnaplinksDisabled.length; i++) {
-        var account = req.accountsSnaplinksDisabled[i];
+    var accountsSnaplinksDisabled = req.accel_gc.accountsSnaplinksDisabled;
+    for (var i = 0; i < accountsSnaplinksDisabled.length; i++) {
+        var account = accountsSnaplinksDisabled[i];
         assert.string(account.uuid, 'account.uuid');
 
         if (account.uuid === uuid) {
@@ -1007,7 +1009,11 @@ module.exports = {
                     1024 * 1024,
                 mpuPrefixDirLen: options.multipartUpload.prefixDirLen
             };
-            req.accountsSnaplinksDisabled = options.accountsSnaplinksDisabled;
+            req.accel_gc = {
+                accountsSnaplinksDisabled: options.accountsSnaplinksDisabled,
+                singlePathEnabled: (options.hasOwnProperty(
+                    'enableSinglePath')) ? options.enableSinglePath : false
+            };
 
             var _opts = {
                 account: req.owner.account,

--- a/lib/link.js
+++ b/lib/link.js
@@ -205,6 +205,69 @@ function checkAccess(req, res, next) {
 }
 
 
+/*
+ * Since the integration of accelerated garbage-collection, new objects in
+ * Manta have a boolean marker field called `singlePath` in their metadata
+ * records. This field's presence indicates that the object has only ever
+ * had a single reference in the metadata tier. If the object we are
+ * attempting to link to has the `singlePath` field, we must clear it before
+ * writing out the 'link' metadata so that inbound deletes to this object
+ * do not default to accelerated garbage-collection.
+ *
+ * It is critical that Muskie update this field on the source object metadata
+ * before writing out the link metadata. If Muskie cleared the field after
+ * writing out the link metadata, a delete for the source object occuring after
+ * Muskie writes out the link metadata, but before Muskie clears the
+ * `singlePath` field on the source object metadata, would result in the source
+ * object being incorrectly garbage-collected with accelerated
+ * garbage-collection. Accelerated garbage-collection is not snaplink-aware,
+ * therefore the 'link' metadata created by this request would become a dangling
+ * reference.
+ *
+ * The disadvantage of clearing the `singlePath` field on the source object
+ * before writing out the 'link' metadata is that Muskie may subsequently fail
+ * while writing out the 'link' metadata. In this case we've cleared the
+ * `singlePath` field on an object that still only has one reference in the
+ * metadata-tier, making the source object ineligible for accelerated
+ * garbage-collection unnecessarily.
+ */
+function clearSinglePathFieldIfPresent(req, res, next) {
+    var log = req.log;
+    var singlePath = 'singlePath';
+    var sourceMetadata = req.link.metadata;
+
+    if (!sourceMetadata.hasOwnProperty(singlePath) ||
+        !sourceMetadata.singlePath) {
+        next();
+        return;
+    }
+
+    /*
+     * For future debugging purposes, we set this field to false instead of
+     * deleting it. This way, we can distinguish between objects that have never
+     * had the `singlePath` field and objects that did, at one point, have it.
+     */
+    sourceMetadata.singlePath = false;
+    sourceMetadata.requestId = req.getId();
+
+    /*
+     * If the client sent 'if-match' or 'if-none-match' headers, make sure that
+     * the source metadata does not change before we clear the `singlePath`
+     * field. This way, the source record is included as part of the data that
+     * is protected from lost updates.
+     */
+    sourceMetadata._etag = req.isConditional() ? req.link.metadata._etag :
+        undefined;
+
+    log.debug(sourceMetadata, 'clearSinglePathIfPresent: entered');
+    req.moray.putMetadata(sourceMetadata, function (err) {
+        if (err)
+            log.debug(err, 'clearSinglePathIfPresent: failed');
+        next(err);
+    });
+}
+
+
 function saveMetadata(req, res, next) {
     var log = req.log;
     common.createMetadata(req, 'link', function (err, opts) {
@@ -251,6 +314,7 @@ module.exports = {
             resolveSource,
             checkAccess,
             restify.conditionalRequest(),
+            clearSinglePathFieldIfPresent,
             saveMetadata
         ];
         return (chain);

--- a/lib/obj.js
+++ b/lib/obj.js
@@ -14,7 +14,7 @@
 // below is some context on what we need to do.
 //
 // Recall that the contract of PUT object is that by default muskie will stream
-// data to 2 backend ZFS hosts in two discreet datacenters (assuming there
+// data to 2 backend ZFS hosts in two discrete datacenters (assuming there
 // exists > 1 datacenter).  In addition, muskie offers test/set semantics on
 // etag, so we need to factor that in as part of this sequence as well.  First,
 // let's list the set of steps that happen (in english):
@@ -933,8 +933,23 @@ function deletePointer(req, res, next) {
      */
     var uuid = req.owner.account.uuid;
     common.checkAccountSnaplinksEnabled(req, uuid, function (enabled) {
-        // Pass in a special header if they are not enabled
-        if (!enabled) {
+        /*
+         * Muskie only processes an object with accelerated garbage-collection
+         * if it can be sure that the object only has one reference in the
+         * metadata tier. Muskie can decide this in one of two ways:
+         *
+         * 1. The creator of the object has snaplinks disabled.
+         * 2. The object being deleted has `singlePath` field set.
+         *
+         * (1) is a contract that states all objects owned by a particular
+         * account have no snaplinks. (2) is a field that all new objects are
+         * born with set to to true. Link metadata for an object can only be
+         * written out if the snaplink request was first able to set
+         * `singlePath` to false on the source object. If a delete for an object
+         * races with a snaplink request with that object as the source, only
+         * one will succeed due to Moray's etag semantics.
+         */
+        if (!enabled || req.metadata.singlePath === true) {
             log.debug({
                 link: req.link,
                 owner: req.owner.account

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "kang": "1.1.0",
         "keep-alive-agent": "0.0.1",
         "keyapi": "git+https://github.com/joyent/keyapi.git#e14b3d58",
-        "libmanta": "git+https://github.com/joyent/node-libmanta.git#v1.1.1",
+        "libmanta": "git+https://github.com/joyent/node-libmanta.git#6052cbc5",
         "libuuid": "0.1.2",
         "lru-cache": "4.1.5",
         "lstream": "0.0.4",

--- a/sapi_manifests/muskie/template
+++ b/sapi_manifests/muskie/template
@@ -179,6 +179,9 @@
     "maximum": 2000
   },
 
+  {{#SINGLE_PATH_ENABLE}}
+  "enableSinglePath": {{SINGLE_PATH_ENABLE}},
+  {{/SINGLE_PATH_ENABLE}}
   {{#MPU_ENABLE}}
   "enableMPU": true,
 


### PR DESCRIPTION
MANTA-3779 Add 'singlePath' field to new object metadata


This PR was migrated-from-gerrit, <https://cr.joyent.us/#/c/5258/>.
The raw archive of this CR is [here](https://github.com/joyent/gerrit-migration/tree/master/archive/5258).
See [MANTA-4594](https://smartos.org/bugview/MANTA-4594) for info on Joyent Eng's migration from Gerrit.

## CR discussion

##### @IanWyszynski commented at 2018-12-17T21:57:21

> Patch Set 1:
> 
> (1 comment)

##### @IanWyszynski commented at 2018-12-17T21:57:28

> Topic set to MANTA-3779

##### @jordanhendricks commented at 2018-12-17T23:30:03

> Patch Set 1:
> 
> (4 comments)
> 
> Hi, Jan! I think this generally looks good. I haven't spent much time reviewing any of the RFD 143 work, so it might be worth having a second set of eyes on this who has if there is anyone that fits that description.
> 
> Does this functionality work with objects created via MPU? I think we probably want to make sure it does, as MPU-created objects should be indistinguishable from objects created via PUT.

##### @IanWyszynski commented at 2018-12-18T21:24:59

> Patch Set 1:
> 
> (4 comments)
> 
> Regarding correctness on MPU objects, is checking that `singlePath` is added to the final object after mpu-commit and checking that this property is set to false when the resulting object is snaplinked sufficient? Are there other cases that I need to be careful about here. Is snaplinking upload-parts permitted?

##### @jordanhendricks commented at 2018-12-19T18:16:24

> Patch Set 1:
> 
> (1 comment)
> 
> > Regarding correctness on MPU objects, is checking that `singlePath` is added to the final object after mpu-commit and checking that this property is set to false when the resulting object is snaplinked sufficient? Are there other cases that I need to be careful about here. 
> 
> If I understand this change correctly, I think the first thing should be sufficient: adding the singlePath property when inserting the object metadata. I don't think there are any other cases that I know of.
> 
> > Is snaplinking upload-parts permitted?
> 
> I wouldn't expect so. Trying in JPC, I see this in a test:
> jordanhendricks$ mln /jhendricks/uploads/d3a/d3aa1075-8405-673a-e6cf-e2b1bbb40333/0 /jhendricks/stor/ln-test
> mln: SourceObjectNotFoundError: /jhendricks/uploads/d3a/d3aa1075-8405-673a-e6cf-e2b1bbb40333/0 was not found
> 
> On the latest bits in master in my dev environment, I see something more troubling:
> 
> $ mln /jhendricks/uploads/6fd/6fdc0aee-912d-41a3-b47e-075f094d52a3/0 /jhendricks/stor/balh
> mln: InternalError: an unexpected error occurred
> 
> I don't have time to look into this right this second, but we probably should at least get a ticket filed.

##### @jordanhendricks commented at 2018-12-19T20:30:56

> Patch Set 1:
> 
> (4 comments)
> 
> (added a couple more comments)

##### @IanWyszynski commented at 2018-12-19T23:21:29

> Patch Set 1:
> 
> (5 comments)
> 
> Filed https://jira.joyent.us/browse/MANTA-4050.

##### @IanWyszynski commented at 2018-12-19T23:28:53

> Patch Set 1:
> 
> (1 comment)

##### Patch Set 1 code comments

> ###### lib/common.js#1013 @jordanhendricks  
> 
> > I suppose the ship might have sailed on the RFD 143 muskie work already, but I prefer to prefix fields hanging off the `req` object (or put them under a parent object -- e.g., req.uploads or req.msk_defaults) to make it more obvious what features they are associated with. There are a lot of fields on that object (from restify, its libraries and muskie itself), so I have found breaking up the namespace to be really useful.
> 
> ###### lib/common.js#1013 @IanWyszynski  
> 
> > What do you think of moving singlePathEnabled to a req.accel_gc object? I could also move accountsSnaplinksDisabled there while I'm at it.
> 
> ###### lib/common.js#1013 @jordanhendricks  
> 
> > I think that sounds good! Thanks.
> 
> ###### lib/common.js#1013 @IanWyszynski  
> 
> > Done
> 
> ###### lib/link.js#209 @jordanhendricks  
> 
> > Might be worth adding: "Since the integration of accelerated garbage collection..." here (or something that is more accurate), to indicate that this hasn't always been true.
> 
> ###### lib/link.js#209 @IanWyszynski  
> 
> > Will do.
> 
> ###### lib/link.js#224 @jordanhendricks  
> 
> > nit: move this sentence to the beginning of the previous paragraph? As it sets up why the implementation works this way.
> 
> ###### lib/link.js#224 @IanWyszynski  
> 
> > Will do.
> 
> ###### lib/link.js#232 @jordanhendricks  
> 
> > Great description. Thanks.
> 
> ###### lib/link.js#232 @IanWyszynski  
> 
> > Done
> 
> ###### lib/link.js#245 @jordanhendricks  
> 
> > Could you more explicitly spell out why checking `sourceMetadata.singlePath` *is* okay, but `req.singlePathEnabled` is not? I presume it is because of what the data source is for sourceMetadata and when it is fetched.
> 
> ###### lib/link.js#245 @IanWyszynski  
> 
> > Does this clarify it?
> > 
> > "In a Manta, no object with the `singlePath` property may exist until all Muskies know to clear that property when they receive snaplink requests. The purpose of `req.singlePathEnabled` is to allow us to configure Muskies to start marking new objects with `singlePath` _after_ every Muskie knows to clear the `singlePath` property on snaplink requests. In order to enforce this ordering during deployment, `req.singlePathEnabled` must not have any bearing on the logic of this handler."
> > 
> > The point I'm trying to express is that the new logic of clearing the singlePath property if it exists should be completely independent of whether the Muskie is creating new objects with `singlePath` set to true.
> 
> ###### lib/link.js#245 @jordanhendricks  
> 
> > I still am not sure I follow. How could a muskie clear the path if it is not updated enough to create new `singlePath` objects?
> 
> ###### lib/link.js#245 @IanWyszynski  
> 
> > The code that makes Muskie aware of the `singlePath` property also includes logic that adds the `singlePath` property to new objects. But Muskie won't start adding the `singlePath` property in putobjects until `req.enableSinglePath` is set to true (it is not present by default).
> > 
> > The `req.enableSinglePath` flag is gating whether Muskie creates objects with `singlePath` property, and not whether it handles existing objects with the `singlePath` property in deletestorage, and putlink requests correctly.
> 
> ###### lib/link.js#245 @IanWyszynski  
> 
> > Thinking about this more, I'd almost be in favor of not bringing up `req.enableSinglePath` here. That flag is gating behavior that has nothing to do with this route.
> 
> ###### lib/link.js#254 @jordanhendricks  
> 
> > Is this for post-mortem debugging? What is the case you're envisioning here?
> 
> ###### lib/link.js#254 @IanWyszynski  
> 
> > To be honest I didn't have an exact use case in mind, but having these 3 states preserves more information that might be useful if we ever want to answer a question that pertains only to objects that once had the `singlePath` flag set to true. 
> > 
> > If we delete the property, it's not as easy to differentiate between objects in Manta that existed before this change was rolled out and objects in Manta that were created after this change was rolled out and then were subsequently snaplinked.
> > 
> > I guess you could still differentiate between by comparing the object creation time to the date on which this change was deployed, but that seems more complex.
> 
> ###### lib/link.js#260 @jordanhendricks  
> 
> > It's probably worth having a brief comment explaining this line as well.
> 
> ###### lib/link.js#260 @IanWyszynski  
> 
> > Will do.
> 
> ###### package.json#30 @IanWyszynski  
> 
> > Will be updated when the node-libmanta change lands: https://cr.joyent.us/#/c/5254

##### @jordanhendricks commented at 2018-12-21T15:43:17

> Patch Set 3: Code-Review+1
> 
> LGTM. I think I would feel more comfortable if someone who has spent more time with the accel GC work takes a look too, as I said before.

##### @IanWyszynski commented at 2019-01-09T01:15:38

> Patch Set 4: Patch Set 3 was rebased

##### @IanWyszynski commented at 2019-01-11T01:39:33

> Patch Set 5: Patch Set 4 was rebased

##### @IanWyszynski commented at 2019-01-31T22:41:28

> Patch Set 7: Patch Set 6 was rebased