### PR TITLE
prototype directory indexes for muskie

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var util = require('util');
@@ -122,16 +122,35 @@ function getDirectory(req, res, next) {
     if (req.metadata.type !== 'directory')
         return (next());
 
+    var isBrowser = false;
+
+    if (req.headers['accept'] !== undefined) {
+        var re = new RegExp('.*text/html.*');
+        if (re.test(req.headers['accept'])) {
+            isBrowser = true;
+        }
+    }
+
     var wroteHead = false;
     function writeHead(err) {
         if (!wroteHead) {
             if (err)
                 return (true);
-
             common.addCustomHeaders(req, res);
-            res.header('Content-Type', DIR_CONTENT_TYPE);
+            if (isBrowser) {
+                res.header('Content-Type', 'text/html');
+            } else {
+                res.header('Content-Type', DIR_CONTENT_TYPE);
+            }
             res.header('Result-Set-Size', req._dircount || 0);
             res.writeHead(200);
+            if (isBrowser) {
+                res.write('<html><head></head><body>\n');
+                res.write(
+                    sprintf('<h1>Index of %s</h1><table border="0">\n',
+                        req.path()));
+                res.write('<tr><td><a href="..">..</a></td></tr>\n');
+            }
             wroteHead = true;
             return (true);
         }
@@ -140,6 +159,9 @@ function getDirectory(req, res, next) {
 
     function done() {
         writeHead();
+        if (isBrowser) {
+            res.write('</table></body></html>');
+        }
         res.end();
         next(false);
     }
@@ -160,8 +182,22 @@ function getDirectory(req, res, next) {
 
         mreq.on('entry', function (entry) {
             writeHead();
-            res.write(JSON.stringify(entry, null, 0) + '\n');
-        });
+            var fname = entry.name;
+            var fsize = entry.size;
+            if (isBrowser) {
+                if (fsize === undefined) {
+                    fname = entry.name + '/';
+                    fsize = '-';
+                }
+                res.write(
+                    sprintf(
+                        '<tr><td><a href="%s">%s</a>' +
+                        '</td><td>%s</td><td>%s</td></tr>\n',
+                        fname, fname, entry.mtime, fsize));
+            } else {
+                res.write(JSON.stringify(entry, null, 0) + '\n');
+            }
+       });
 
         mreq.once('end', done);
     } else {


### PR DESCRIPTION
prototype directory indexes for muskie


This PR was migrated-from-gerrit, <https://cr.joyent.us/#/c/6869/>.
The raw archive of this CR is [here](https://github.com/joyent/gerrit-migration/tree/master/archive/6869).
See [MANTA-4594](https://smartos.org/bugview/MANTA-4594) for info on Joyent Eng's migration from Gerrit.

## CR discussion

##### @timfoster commented at 2019-09-04T14:32:44

> Uploaded patch set 2: Patch Set 1 was rebased.