### PR TITLE
MANTA-4670 MPU routes without names are blowing up metrics cardinality

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -558,7 +558,8 @@ function addMultipartUploadRoutes(server) {
     }, uploads.createHandler());
 
     server.put({
-        path: '/:account/uploads'
+        path: '/:account/uploads',
+        name: 'PutUploads'
     }, forbiddenHandler);
 
     // Redirects
@@ -568,51 +569,61 @@ function addMultipartUploadRoutes(server) {
     var uploadsRedirectPathPart = '/:account/uploads/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/:partNum';
     server.get({
         path: uploadsRedirectPath,
+        name: 'GetUploadRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.put({
         path: uploadsRedirectPath,
+        name: 'PutUploadRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.head({
         path: uploadsRedirectPath,
+        name: 'HeadUploadRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.del({
         path: uploadsRedirectPath,
+        name: 'DeleteUploadRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.post({
         path: uploadsRedirectPath,
+        name: 'PostUploadRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.get({
         path: uploadsRedirectPathPart,
+        name: 'GetUploadPartRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.put({
         path: uploadsRedirectPathPart,
+        name: 'PutUploadPartRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.head({
         path: uploadsRedirectPathPart,
+        name: 'HeadUploadPartRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.del({
         path: uploadsRedirectPathPart,
+        name: 'DeleteUploadPartRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
     server.post({
         path: uploadsRedirectPathPart,
+        name: 'PostUploadPartRedirect',
         contentType: '*/*'
     }, uploads.redirectHandler());
 
@@ -624,23 +635,27 @@ function addMultipartUploadRoutes(server) {
      */
     server.get({
         path: '/:account/uploads/[0-f]+/:id/state',
-        name: 'GetUpload'
+        name: 'GetUploadState'
     }, uploads.getHandler());
 
     server.head({
-        path: '/:account/uploads/[0-f]+/:id/state'
+        path: '/:account/uploads/[0-f]+/:id/state',
+        name: 'HeadUploadState'
     }, forbiddenHandler);
 
     server.put({
-        path: '/:account/uploads/[0-f]+/:id/state'
+        path: '/:account/uploads/[0-f]+/:id/state',
+        name: 'PutUploadState'
     }, forbiddenHandler);
 
     server.post({
-        path: '/:account/uploads/[0-f]+/:id/state'
+        path: '/:account/uploads/[0-f]+/:id/state',
+        name: 'PostUploadState'
     }, forbiddenHandler);
 
     server.del({
-        path: '/:account/uploads/[0-f]+/:id/state'
+        path: '/:account/uploads/[0-f]+/:id/state',
+        name: 'DeleteUploadState'
     }, forbiddenHandler);
 
     /*
@@ -655,19 +670,23 @@ function addMultipartUploadRoutes(server) {
     }, uploads.abortHandler());
 
     server.get({
-        path: '/:account/uploads/[0-f]+/:id/abort'
+        path: '/:account/uploads/[0-f]+/:id/abort',
+        name: 'GetAbortUpload'
     }, forbiddenHandler);
 
     server.put({
-        path: '/:account/uploads/[0-f]+/:id/abort'
+        path: '/:account/uploads/[0-f]+/:id/abort',
+        name: 'PutAbortUpload'
     }, forbiddenHandler);
 
     server.head({
-        path: '/:account/uploads/[0-f]+/:id/abort'
+        path: '/:account/uploads/[0-f]+/:id/abort',
+        name: 'HeadAbortUpload'
     }, forbiddenHandler);
 
     server.del({
-        path: '/:account/uploads/[0-f]+/:id/abort'
+        path: '/:account/uploads/[0-f]+/:id/abort',
+        name: 'DeleteAbortUpload'
     }, forbiddenHandler);
 
     /*
@@ -683,19 +702,23 @@ function addMultipartUploadRoutes(server) {
     }, uploads.commitHandler());
 
     server.get({
-        path: '/:account/uploads/[0-f]+/:id/commit'
+        path: '/:account/uploads/[0-f]+/:id/commit',
+        name: 'GetCommitUpload'
     }, forbiddenHandler);
 
     server.put({
-        path: '/:account/uploads/[0-f]+/:id/commit'
+        path: '/:account/uploads/[0-f]+/:id/commit',
+        name: 'PutCommitUpload'
     }, forbiddenHandler);
 
     server.head({
-        path: '/:account/uploads/[0-f]+/:id/commit'
+        path: '/:account/uploads/[0-f]+/:id/commit',
+        name: 'HeadCommitUpload'
     }, forbiddenHandler);
 
     server.del({
-        path: '/:account/uploads/[0-f]+/:id/commit'
+        path: '/:account/uploads/[0-f]+/:id/commit',
+        name: 'DeleteCommitUpload'
     }, forbiddenHandler);
 }
 
@@ -713,15 +736,17 @@ function addMultipartUploadDataPlaneRoutes(server) {
      */
     server.del({
         path: '/:account/uploads/[0-f]+/:id',
-        name: 'DelUploadDir'
+        name: 'DeleteUploadDir'
     }, uploads.delUploadDirHandler());
 
     server.put({
-        path: '/:account/uploads/[0-f]+/:id'
+        path: '/:account/uploads/[0-f]+/:id',
+        name: 'PutUploadDir'
     }, forbiddenHandler);
 
     server.post({
-        path: '/:account/uploads/[0-f]+/:id'
+        path: '/:account/uploads/[0-f]+/:id',
+        name: 'PostUploadDir'
     }, forbiddenHandler);
 
     /*
@@ -732,7 +757,7 @@ function addMultipartUploadDataPlaneRoutes(server) {
      */
     server.del({
         path: '/:account/uploads/[0-f]+/:id/:partNum',
-        name: 'DelPart'
+        name: 'DeletePart'
     }, uploads.delPartHandler());
 
     server.put({
@@ -742,11 +767,13 @@ function addMultipartUploadDataPlaneRoutes(server) {
     }, uploads.uploadPartHandler());
 
     server.get({
-        path: '/:account/uploads/[0-f]+/:id/:partNum'
+        path: '/:account/uploads/[0-f]+/:id/:partNum',
+        name: 'GetPart'
     }, forbiddenHandler);
 
     server.post({
-        path: '/:account/uploads/[0-f]+/:id/:partNum'
+        path: '/:account/uploads/[0-f]+/:id/:partNum',
+        name: 'PostPart'
     }, forbiddenHandler);
 }
 


### PR DESCRIPTION
Before this change buckets-api produces metrics with incorrect labels, similar to the ones below

```
http_requests_completed{operation="getaccountuploadsaf098af094af094af094af0912102",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="82079"} 1
http_requests_completed{operation="putaccountuploadsaf098af094af094af094af0912102",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="82079"} 1
http_requests_completed{operation="headaccountuploadsaf098af094af094af094af0912102",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="82079"} 1
```

This change gives names for all MPU route to fix the issue. With this change we get correct metric labels
```
http_requests_completed{operation="getuploadredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
http_requests_completed{operation="putuploadredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
http_requests_completed{operation="headuploadredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
http_requests_completed{operation="postuploadredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
http_requests_completed{operation="deleteuploadredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
http_requests_completed{operation="getuploadpartredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
http_requests_completed{operation="putuploadpartredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
http_requests_completed{operation="headuploadpartredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
http_requests_completed{operation="postuploadpartredirect",method="unknown",statusCode="301",datacenter="us-central-1c",server="131f564f-d49b-1165-d46a-b8aeedeb1c3e",zonename="41866507-d326-48f9-c2b6-aa044f2ffcb6",pid="27365"} 1
```