### PR TITLE
joyent/manta-muskie#30 HEAD request should return an Accept-Ranges header

### DIFF
--- a/lib/obj.js
+++ b/lib/obj.js
@@ -731,6 +731,7 @@ function streamFromSharks(req, res, next) {
         res.header('Content-Length', md.contentLength);
         res.header('Content-MD5', md.contentMD5);
         res.header('Content-Type', md.contentType);
+        res.header('Accept-Ranges', 'bytes');
         res.send(200);
         next();
         return;

--- a/test/obj.test.js
+++ b/test/obj.test.js
@@ -625,6 +625,21 @@ test('get ok', function (t) {
 });
 
 
+test('head ok', function (t) {
+    var self = this;
+    this.putObject(t, function () {
+        self.client.head(self.key, function (err, stream, res) {
+            t.ifError(err);
+            t.equal(res.headers['content-type'], 'text/plain');
+            t.ok(res.headers.etag);
+            t.ok(res.headers['last-modified']);
+            t.equal('bytes', res.headers['accept-ranges']);
+            t.end();
+        });
+    });
+});
+
+
 test('get 404', function (t) {
     this.client.get(this.key + 'a', function (err, stream, res) {
         t.ok(err);


### PR DESCRIPTION
See #30 

Tested by running the test suite, and also manually doing `curl -I` a bit.

Verified that my target http client (an Erlang http client) now decides to use range requests properly.