### PR TITLE
MANTA-4717 Remove support for creating new SnapLinks

### DIFF
--- a/etc/config.coal.json
+++ b/etc/config.coal.json
@@ -95,7 +95,7 @@
                 "resolvers": ["nameservice.coal.joyent.us"]
             }
         },
-    "defaultMaxStreamingSizeMB": 5120
+        "defaultMaxStreamingSizeMB": 5120
     },
     "sharkConfig": {
         "connectTimeout": 2000,

--- a/etc/config.coal.json
+++ b/etc/config.coal.json
@@ -27,6 +27,7 @@
         "maxTranslationCacheSize": 1000,
         "maxTranslationCacheAgeMs": 300
     },
+    "accountsSnaplinksDisabled": [],
     "moray": {
         "morayOptions": {
             "srvDomain": "electric-moray.coal.joyent.us",

--- a/etc/config.coal.json
+++ b/etc/config.coal.json
@@ -27,7 +27,6 @@
         "maxTranslationCacheSize": 1000,
         "maxTranslationCacheAgeMs": 300
     },
-    "accountsSnaplinksDisabled": [],
     "moray": {
         "morayOptions": {
             "srvDomain": "electric-moray.coal.joyent.us",
@@ -37,12 +36,12 @@
         }
     },
     "marlin": {
-	"moray": {
+        "moray": {
             "srvDomain": "1.moray.coal.joyent.us",
             "cueballOptions": {
                 "resolvers": [ "nameservice.coal.joyent.us" ]
             }
-	},
+        },
         "jobCache": {
             "size": 500,
             "expiry": 30
@@ -96,7 +95,7 @@
                 "resolvers": ["nameservice.coal.joyent.us"]
             }
         },
-	"defaultMaxStreamingSizeMB": 5120
+    "defaultMaxStreamingSizeMB": 5120
     },
     "sharkConfig": {
         "connectTimeout": 2000,

--- a/lib/audit.js
+++ b/lib/audit.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2019 Joyent Inc.
  */
 
 var assert = require('assert-plus');
@@ -308,30 +308,19 @@ function auditLogger(options) {
             var owner = md.creator || md.owner;
 
             /*
-             * Count bytes for which DELETE API requests have been completed. If
-             * the owner of the underlying data has snaplinks disabled, then
-             * the deleted object was processed by the accelerated deletion
-             * pipeline.
+             * Count bytes for which DELETE API requests have been completed.
+             *
+             * The intent of 'deleted_data_counter' is to count only
+             * deletes that unlink object backing files from storage
+             * node filesystems. Directory deletes, zero byte object
+             * deletes are omitted from this count.
              */
-            if (owner) {
-                common.checkAccountSnaplinksEnabled(req, owner,
-                    function (enabled) {
-                    /*
-                     * The intent of 'deleted_data_counter' is to count only
-                     * deletes that unlink object backing files from storage
-                     * node filesystems. Directory deletes, zero byte object
-                     * deletes, and snaplink deletes are omitted from this
-                     * count.
-                     */
-                    if (md.type === 'object' && md.contentLength > 0) {
-                        var storage = md.contentLength * md.sharks.length;
-                        labels = {
-                            accelerated_gc: !enabled,
-                            owner: owner
-                        };
-                        deleted_data_counter.add(storage, labels);
-                    }
-                });
+            if (md.type === 'object' && md.contentLength > 0) {
+                var storage = md.contentLength * md.sharks.length;
+                labels = {
+                    owner: owner
+                };
+                deleted_data_counter.add(storage, labels);
             }
         }
 

--- a/lib/audit.js
+++ b/lib/audit.js
@@ -308,19 +308,30 @@ function auditLogger(options) {
             var owner = md.creator || md.owner;
 
             /*
-             * Count bytes for which DELETE API requests have been completed.
-             *
-             * The intent of 'deleted_data_counter' is to count only
-             * deletes that unlink object backing files from storage
-             * node filesystems. Directory deletes, zero byte object
-             * deletes are omitted from this count.
+             * Count bytes for which DELETE API requests have been completed. If
+             * the owner of the underlying data has snaplinks disabled, then
+             * the deleted object was processed by the accelerated deletion
+             * pipeline.
              */
-            if (md.type === 'object' && md.contentLength > 0) {
-                var storage = md.contentLength * md.sharks.length;
-                labels = {
-                    owner: owner
-                };
-                deleted_data_counter.add(storage, labels);
+            if (owner) {
+                common.checkAccountSnaplinksMightExist(req, owner,
+                    function (mightExist) {
+                    /*
+                     * The intent of 'deleted_data_counter' is to count only
+                     * deletes that unlink object backing files from storage
+                     * node filesystems. Directory deletes, zero byte object
+                     * deletes, and snaplink deletes are omitted from this
+                     * count.
+                     */
+                    if (md.type === 'object' && md.contentLength > 0) {
+                        var storage = md.contentLength * md.sharks.length;
+                        labels = {
+                            accelerated_gc: !mightExist,
+                            owner: owner
+                        };
+                        deleted_data_counter.add(storage, labels);
+                    }
+                });
             }
         }
 

--- a/lib/audit.js
+++ b/lib/audit.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var assert = require('assert-plus');

--- a/lib/common.js
+++ b/lib/common.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2019 Joyent Inc.
  */
 
 var EventEmitter = require('events').EventEmitter;
@@ -333,41 +333,6 @@ function ensureEntryExists(req, res, next) {
     } else {
         next();
     }
-}
-
-
-/*
- * This function is used to abstract away the logic involved in checking
- * that a particular account uuid has snaplinks enabled. Today, it is
- * called in the `ensureSnaplinksEnabled` method defined in this module
- * and in the putlinkHandler chain to verify that the source object (the
- * object being linked to) is not owned by an account for which snaplinks
- * are enabled.
- */
-function checkAccountSnaplinksEnabled(req, uuid, next) {
-    for (var i = 0; i < req.accountsSnaplinksDisabled.length; i++) {
-        var account = req.accountsSnaplinksDisabled[i];
-        assert.string(account.uuid, 'account.uuid');
-
-        if (account.uuid === uuid) {
-            next(false);
-            return;
-        }
-    }
-    next(true);
-}
-
-
-function ensureSnaplinksEnabled(req, res, next) {
-    checkAccountSnaplinksEnabled(req, req.caller.account.uuid,
-        function (enabled) {
-        if (!enabled) {
-            next(new SnaplinksDisabledError('snaplinks have been disabled ' +
-                'for this account'));
-            return;
-        }
-    });
-    next();
 }
 
 
@@ -1053,10 +1018,6 @@ module.exports = {
         return (ensureEntryExists);
     },
 
-    ensureSnaplinksEnabledHandler: function () {
-        return (ensureSnaplinksEnabled);
-    },
-
     ensureNotDirectoryHandler: function () {
         return (ensureNotDirectory);
     },
@@ -1072,8 +1033,6 @@ module.exports = {
     getMetadataHandler: function () {
         return (getMetadata);
     },
-
-    checkAccountSnaplinksEnabled: checkAccountSnaplinksEnabled,
 
     setupHandler: function (options, clients) {
         assert.object(options, 'options');
@@ -1108,7 +1067,6 @@ module.exports = {
                     1024 * 1024,
                 mpuPrefixDirLen: options.multipartUpload.prefixDirLen
             };
-            req.accountsSnaplinksDisabled = options.accountsSnaplinksDisabled;
 
             // Write request setup
             if (!req.isReadOnly()) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -352,8 +352,13 @@ function ensureEntryExists(req, res, next) {
  */
 function checkAccountSnaplinksMightExist(req, uuid, next) {
     if (req.config.snaplinkCleanupRequired !== true) {
-        // We've run the cleanup and this Manta is SnapLink-free, so snaplinks
+        //
+        // We've run the cleanup and this Manta is SnapLink-free, so SnapLinks
         // will not exist for this account.
+        //
+        // Alternatively, this DC was setup with Manta v2 initially in which
+        // case SnapLinks will also not exist for this account.
+        //
         next(false);
         return;
     }

--- a/lib/common.js
+++ b/lib/common.js
@@ -336,6 +336,44 @@ function ensureEntryExists(req, res, next) {
 }
 
 
+/*
+ * This function is used to abstract away the logic involved in checking
+ * that a particular account uuid potentially has existing SnapLinks.
+ * An account is assumed to have no SnapLinks if:
+ *
+ *  * they are in the accountsSnaplinksDisabled array; or
+ *  * we have completed the audit and "fixed" the system so that there are no
+ *    longer *any* SnapLinks for any account.
+ *
+ * in either case, next() will be called with `false`. Otherwise next() will be
+ * called with `true`.
+ */
+function checkAccountSnaplinksMightExist(req, uuid, next) {
+    req.log.warn({
+        config: req.config
+    }, 'checkAccountSnaplinksMightExist: entered');
+
+    if (req.config.snaplinkCleanupComplete) {
+        // We've run the cleanup and this Manta is SnapLink-free, so snaplinks
+        // will not exist for this account.
+        next(false);
+        return;
+    }
+
+    for (var i = 0; i < req.accountsSnaplinksDisabled.length; i++) {
+        var account = req.accountsSnaplinksDisabled[i];
+        assert.string(account.uuid, 'account.uuid');
+
+        if (account.uuid === uuid) {
+            next(false);
+            return;
+        }
+    }
+
+    next(true);
+}
+
+
 function ensureNotDirectory(req, res, next) {
     if (!req.metadata) {
         next(new DirectoryOperationError(req));
@@ -1034,6 +1072,8 @@ module.exports = {
         return (getMetadata);
     },
 
+    checkAccountSnaplinksMightExist: checkAccountSnaplinksMightExist,
+
     setupHandler: function (options, clients) {
         assert.object(options, 'options');
         assert.object(clients, 'clients');
@@ -1067,6 +1107,7 @@ module.exports = {
                     1024 * 1024,
                 mpuPrefixDirLen: options.multipartUpload.prefixDirLen
             };
+            req.accountsSnaplinksDisabled = options.accountsSnaplinksDisabled;
 
             // Write request setup
             if (!req.isReadOnly()) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -349,10 +349,6 @@ function ensureEntryExists(req, res, next) {
  * called with `true`.
  */
 function checkAccountSnaplinksMightExist(req, uuid, next) {
-    req.log.warn({
-        config: req.config
-    }, 'checkAccountSnaplinksMightExist: entered');
-
     if (req.config.snaplinkCleanupComplete) {
         // We've run the cleanup and this Manta is SnapLink-free, so snaplinks
         // will not exist for this account.

--- a/lib/common.js
+++ b/lib/common.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var EventEmitter = require('events').EventEmitter;

--- a/lib/common.js
+++ b/lib/common.js
@@ -343,13 +343,15 @@ function ensureEntryExists(req, res, next) {
  *
  *  * they are in the accountsSnaplinksDisabled array; or
  *  * we have completed the audit and "fixed" the system so that there are no
- *    longer *any* SnapLinks for any account.
+ *    longer *any* SnapLinks for any account. If we upgraded from Manta v1, the
+ *    upgrade will have set "SNAPLINK_CLEANUP_REQUIRED". When that is gone, the
+ *    cleanup has been completed.
  *
  * in either case, next() will be called with `false`. Otherwise next() will be
  * called with `true`.
  */
 function checkAccountSnaplinksMightExist(req, uuid, next) {
-    if (req.config.snaplinkCleanupComplete) {
+    if (req.config.snaplinkCleanupRequired !== true) {
         // We've run the cleanup and this Manta is SnapLink-free, so snaplinks
         // will not exist for this account.
         next(false);

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent Inc.
  */
 
 var fs = require('fs');
@@ -79,19 +79,6 @@ function configure(appName, opts, dtProbes) {
     setNumericConfigProperty('defaultMaxStreamingSizeMB',
         DEF_MAX_STREAMING_SIZE_MB, cfg.storage, cfg.log,
         function (x) { return (x >= 1); });
-
-    if (!cfg.hasOwnProperty('accountsSnaplinksDisabled')) {
-        cfg.accountsSnaplinksDisabled = [];
-    } else {
-        assert.arrayOfObject(cfg.accountsSnaplinksDisabled,
-            'cfg.accountsSnaplinksDisabled');
-        for (var i = 0; i < cfg.accountsSnaplinksDisabled.length; i++) {
-            var uuid = cfg.accountsSnaplinksDisabled[i].uuid;
-
-            assert.uuid(uuid, 'cfg.accountsSnaplinksDisabled[i].uuid');
-            cfg.log.info('snaplinks disabled for uuid ' + uuid);
-        }
-    }
 
     if (!cfg.hasOwnProperty('multipartUpload')) {
         cfg.multipartUpload = {};

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent Inc.
+ * Copyright (c) 2019, Joyent, Inc.
  */
 
 var fs = require('fs');
@@ -79,6 +79,19 @@ function configure(appName, opts, dtProbes) {
     setNumericConfigProperty('defaultMaxStreamingSizeMB',
         DEF_MAX_STREAMING_SIZE_MB, cfg.storage, cfg.log,
         function (x) { return (x >= 1); });
+
+    if (!cfg.hasOwnProperty('accountsSnaplinksDisabled')) {
+        cfg.accountsSnaplinksDisabled = [];
+    } else {
+        assert.arrayOfObject(cfg.accountsSnaplinksDisabled,
+            'cfg.accountsSnaplinksDisabled');
+        for (var i = 0; i < cfg.accountsSnaplinksDisabled.length; i++) {
+            var uuid = cfg.accountsSnaplinksDisabled[i].uuid;
+
+            assert.uuid(uuid, 'cfg.accountsSnaplinksDisabled[i].uuid');
+            cfg.log.info('snaplinks disabled for uuid ' + uuid);
+        }
+    }
 
     if (!cfg.hasOwnProperty('multipartUpload')) {
         cfg.multipartUpload = {};

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var fs = require('fs');
@@ -364,7 +364,7 @@ function version() {
     // compatible with the old tools and is likely to remain so. If not, this
     // will need to be bumped too.
     //
-    return (1.0.3);
+    return ('1.0.3');
 }
 
 

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -355,9 +355,16 @@ function readFile(file) {
 
 
 function version() {
-    var fname = __dirname + '/../package.json';
-    var pkg = fs.readFileSync(fname, 'utf8');
-    return (JSON.parse(pkg).version);
+    //
+    // The last package.json version of manta before the manta v2 split was
+    // 1.0.2. This used to use the package.json version and clients are
+    // depending on ~1.0. Since Manta wanted to go to v2, we need to hardcode
+    // this so that old clients still work even as functionality is deprecated
+    // in Manta v2. The functionality that *does* still exist, is still
+    // compatible with the old tools and is likely to remain so. If not, this
+    // will need to be bumped too.
+    //
+    return (1.0.3);
 }
 
 

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -55,7 +55,7 @@ function configure(appName, opts, dtProbes) {
     cfg.insecurePort = opts.insecure_port || cfg.insecurePort;
     cfg.port = opts.port || cfg.port;
     cfg.name = 'Manta';
-    cfg.version = version();
+    cfg.version = apiVersion();
     cfg.log = configureLogging(appName, cfg.bunyan, opts.verbose);
 
     [ cfg.auth, cfg.marlin, cfg.moray, cfg.medusa,
@@ -354,7 +354,7 @@ function readFile(file) {
 }
 
 
-function version() {
+function apiVersion() {
     //
     // The last package.json version of manta before the manta v2 split was
     // 1.0.2. This used to use the package.json version and clients are

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -356,15 +356,14 @@ function readFile(file) {
 
 function apiVersion() {
     //
-    // The last package.json version of manta before the manta v2 split was
-    // 1.0.2. This used to use the package.json version and clients are
-    // depending on ~1.0. Since Manta wanted to go to v2, we need to hardcode
-    // this so that old clients still work even as functionality is deprecated
-    // in Manta v2. The functionality that *does* still exist, is still
-    // compatible with the old tools and is likely to remain so. If not, this
-    // will need to be bumped too.
+    // This used to use the package.json version and clients are depending on
+    // ~1.0. Since Manta wanted to go to v2, we need to hardcode this so that
+    // old clients still work even as functionality is deprecated in Manta v2.
+    // The functionality that *does* still exist, is still compatible with the
+    // old tools and is likely to remain so. If not, this will need to be bumped
+    // too and all clients updated.
     //
-    return ('1.0.3');
+    return ('1.0.0');
 }
 
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -5,234 +5,21 @@
  */
 
 /*
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2019 Joyent Inc.
  */
 
-var url = require('url');
-
-var libmanta = require('libmanta');
-var restify = require('restify');
-
-var common = require('./common');
 require('./errors');
 
 
+function snapLinksDisabled(req, res, next) {
+    var log = req.log;
 
-///--- Helpers
-
-// From restify
-function sanitizePath(p) {
-
-    // Be nice like apache and strip out any //my//foo//bar///blah
-    p = p.replace(/\/\/+/g, '/');
-
-    // Kill a trailing '/'
-    if (p.lastIndexOf('/') === (p.length - 1) && p.length > 1)
-        p = p.substr(0, p.length - 1);
-
-    return (p);
-}
-
-
-
-///--- Routes
-//
-// We only have put handlers, as once a link is written in the system all the
-// object APIs "just work". (note that on creating a new link, we actually set
-// the type to 'object' -> you can distinguish that an object was created via
-// link by checking the createdFrom attribute in moray).
-//
-
-
-//-- PUT Handlers --//
-
-function parseLocation(req, res, next) {
-    if (!req.headers.location)
-        return (next(new LinkRequiredError()));
-
-    req.link = {
-        owner: {}
-    };
-
-    try {
-        req.link.path =
-            sanitizePath(url.parse(req.headers.location).pathname);
-
-        var re;
-
-        if (common.STOR_PATH.test(req.link.path)) {
-            re = common.STOR_PATH;
-        } else if (common.PUBLIC_STOR_PATH.test(req.link.path)) {
-            re = common.PUBLIC_STOR_PATH;
-        } else if (common.JOBS_STOR_PATH.test(req.link.path)) {
-            re = common.JOBS_STOR_PATH;
-        } else if (common.REPORTS_STOR_PATH.test(req.link.path)) {
-            re = common.REPORTS_STOR_PATH;
-        }
-
-        if (re) {
-            var params = re.exec(req.link.path);
-            req.link.owner.login = decodeURIComponent(params[1]);
-        }
-
-    } catch (e) {
-        return (next(new InvalidLinkError(req)));
-    }
-
-    req.log.debug({
+    log.warn({
         link: req.link
-    }, 'parseLocation: done');
-    next();
+    }, 'Rejecting attempt to create SnapLink');
+
+    next(new SnaplinksDisabledError('Manta v2 does not support SnapLinks.'));
 }
-
-
-function resolveOwner(req, res, next) {
-    var log = req.log;
-    var login = req.link.owner.login;
-
-    log.debug('link.resolveOwner: entered');
-    req.mahi.getUser(common.ANONYMOUS_USER, login, true, function (err, info) {
-        if (err) {
-            switch (err.restCode) {
-            case 'AccountDoesNotExist':
-                next(new LinkNotFoundError(req));
-                return;
-            default:
-                next(new InternalError(err));
-                return;
-            }
-        }
-        req.link.owner = info;
-        var _opts = {
-            account: req.link.owner.account,
-            path: req.link.path
-        };
-        libmanta.normalizeMantaPath(_opts, function (err2, p) {
-            if (err2) {
-                req.log.debug(err2, 'Invalid link');
-                next(new InvalidLinkError(req));
-                return;
-            }
-            req.link.key = p;
-            log.debug({
-                link: req.link,
-                owner: req.link.owner
-            }, 'link.resolveOwner: done');
-            next();
-        });
-    });
-}
-
-
-function ensureSourceOwnerSnaplinksEnabled(req, res, next) {
-    var log = req.log;
-    var uuid = req.link.owner.account.uuid;
-
-    common.checkAccountSnaplinksEnabled(req, uuid, function (enabled) {
-        if (!enabled) {
-            log.debug({
-                link: req.link,
-                owner: req.link.owner
-            }, 'link.ensureSourceOwnerSnaplinksEnabled: source owner ' +
-                'has snaplinks disabled');
-            next(new SnaplinksDisabledError('owner of source object has ' +
-                'snaplinks disabled'));
-            return;
-        }
-        next();
-    });
-}
-
-
-function resolveSource(req, res, next) {
-    var log = req.log;
-    var opts = {
-        key: req.link.key,
-        requestId: req.getId()
-    };
-
-    log.debug({link: req.link}, 'resolveSource: entered');
-
-    common.loadMetadata(req, opts, function (err, md) {
-        if (err) {
-            next(err);
-        } else if (!md || md.type === null) {
-            return (next(new LinkNotFoundError(req)));
-        } else if (md.type !== 'object') {
-            return (next(new LinkNotObjectError(req)));
-        } else {
-            req.link.metadata = md;
-
-            // Conditional request needs these
-            res.set('Etag', md.etag);
-            if (md.mtime)
-                res.set('Last-Modified', new Date(md.mtime));
-
-            log.debug({link: req.link}, 'resolveSource: done');
-            next();
-        }
-    });
-}
-
-
-function checkAccess(req, res, next) {
-    req.log.debug({
-        caller: req.caller,
-        target: req.owner,
-        linkSource: req.link,
-        path: req.path()
-    }, 'link.authorize: entered');
-
-    req.authContext.action = 'getobject';
-    req.authContext.resource = {
-        owner: req.link.owner,
-        key: req.link.key,
-        roles: req.link.metadata.roles
-    };
-
-    try {
-        libmanta.authorize({
-            mahi: req.mahi,
-            context: req.authContext
-        });
-    } catch (e) {
-        next(new AuthorizationError(req.owner.account.login, req.link.path, e));
-        return;
-    }
-
-    req.log.debug('link.authorize: ok');
-    next();
-}
-
-
-function saveMetadata(req, res, next) {
-    var log = req.log;
-    common.createMetadata(req, 'link', function (err, opts) {
-        if (err) {
-            next(err);
-            return;
-        }
-
-        opts.creator = req.link.metadata.creator || req.link.metadata.owner;
-        opts.previousMetadata = req.metadata;
-
-        log.debug(opts, 'saveMetadata: entered');
-        req.moray.putMetadata(opts, function (err2) {
-            if (err2) {
-                log.debug(err2, 'saveMetadata: failed');
-                next(err2);
-            } else {
-                var lmd = req.link.metadata;
-                log.debug('saveMetadata: done');
-                res.header('Etag', lmd.etag);
-                res.header('Last-Modified', new Date(lmd.mtime));
-                res.send(204);
-                next();
-            }
-        });
-    });
-}
-
 
 
 ///--- Exports
@@ -241,17 +28,7 @@ module.exports = {
 
     putLinkHandler: function () {
         var chain = [
-            common.ensureSnaplinksEnabledHandler(),
-            common.ensureNotRootHandler(),
-            common.ensureNotDirectoryHandler(),
-            common.ensureParentHandler(),
-            parseLocation,
-            resolveOwner,
-            ensureSourceOwnerSnaplinksEnabled,
-            resolveSource,
-            checkAccess,
-            restify.conditionalRequest(),
-            saveMetadata
+            snapLinksDisabled
         ];
         return (chain);
     }

--- a/lib/link.js
+++ b/lib/link.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 require('./errors');

--- a/lib/link.js
+++ b/lib/link.js
@@ -12,8 +12,6 @@ require('./errors');
 
 
 function rejectAllSnapLinks(req, res, next) {
-    var log = req.log;
-
     next(new SnaplinksDisabledError('Manta v2 does not support SnapLinks.'));
 }
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -11,12 +11,8 @@
 require('./errors');
 
 
-function snapLinksDisabled(req, res, next) {
+function rejectAllSnapLinks(req, res, next) {
     var log = req.log;
-
-    log.warn({
-        link: req.link
-    }, 'Rejecting attempt to create SnapLink');
 
     next(new SnaplinksDisabledError('Manta v2 does not support SnapLinks.'));
 }
@@ -28,7 +24,7 @@ module.exports = {
 
     putLinkHandler: function () {
         var chain = [
-            snapLinksDisabled
+            rejectAllSnapLinks
         ];
         return (chain);
     }

--- a/lib/obj.js
+++ b/lib/obj.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2019 Joyent Inc.
  */
 
 //
@@ -931,21 +931,6 @@ function deletePointer(req, res, next) {
 
     log.debug(opts, 'deletePointer: entered');
 
-    /*
-     * Let the delete mechanism know that snaplinks are disabled for this
-     * account, so it can treat the object differently
-     */
-    var uuid = req.owner.account.uuid;
-    common.checkAccountSnaplinksEnabled(req, uuid, function (enabled) {
-        // Pass in a special header if they are not enabled
-        if (!enabled) {
-            log.debug({
-                link: req.link,
-                owner: req.owner.account
-            }, 'deletePointer: owner of object has snaplinks disabled');
-            opts.snapLinksDisabled = true;
-        }
-    });
     req.moray.delMetadata(opts, function (err) {
         if (err) {
             next(err);

--- a/lib/obj.js
+++ b/lib/obj.js
@@ -931,6 +931,25 @@ function deletePointer(req, res, next) {
 
     log.debug(opts, 'deletePointer: entered');
 
+    /*
+     * Let the delete mechanism know whether there might be SnapLinks that still
+     * exist for this account, so it can treat the object differently.
+     */
+    var uuid = req.owner.account.uuid;
+    common.checkAccountSnaplinksMightExist(req, uuid, function (mightExist) {
+        // Pass in a header if they are guaranteed not to exist
+        if (!mightExist) {
+            log.debug({
+                link: req.link,
+                owner: req.owner.account
+            }, 'deletePointer: snaplinks do not exist for account');
+
+            // Note: `Disabled` is historical here. This can all go away once
+            // cleanup has been run everywhere and we don't need to worry about
+            // SnapLinks any more.
+            opts.snapLinksDisabled = true;
+        }
+    });
     req.moray.delMetadata(opts, function (err) {
         if (err) {
             next(err);

--- a/lib/obj.js
+++ b/lib/obj.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 //

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "muskie",
     "description": "Manta public-facing WebAPI",
-    "version": "1.0.2",
+    "version": "2.0.0",
     "author": "Joyent (joyent.com)",
     "private": true,
     "repository": {
@@ -28,7 +28,7 @@
         "kang": "1.1.0",
         "keep-alive-agent": "0.0.1",
         "keyapi": "git+https://github.com/joyent/keyapi.git#e14b3d58",
-        "libmanta": "git+https://github.com/joyent/node-libmanta.git#v1.3.0",
+        "libmanta": "git+https://github.com/joyent/node-libmanta.git#MANTA-4717",
         "libuuid": "0.1.2",
         "lru-cache": "4.1.5",
         "lstream": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "muskie",
     "description": "Manta public-facing WebAPI",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "author": "Joyent (joyent.com)",
     "private": true,
     "repository": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "kang": "1.1.0",
         "keep-alive-agent": "0.0.1",
         "keyapi": "git+https://github.com/joyent/keyapi.git#e14b3d58",
-        "libmanta": "git+https://github.com/joyent/node-libmanta.git#MANTA-4717",
+        "libmanta": "git+https://github.com/joyent/node-libmanta.git#v1.3.0",
         "libuuid": "0.1.2",
         "lru-cache": "4.1.5",
         "lstream": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "muskie",
     "description": "Manta public-facing WebAPI",
-    "version": "1.0.3",
+    "version": "2.0.0",
     "author": "Joyent (joyent.com)",
     "private": true,
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "muskie",
     "description": "Manta public-facing WebAPI",
-    "version": "2.0.0",
+    "version": "1.0.3",
     "author": "Joyent (joyent.com)",
     "private": true,
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "muskie",
     "description": "Manta public-facing WebAPI",
-    "version": "1.1.0",
+    "version": "1.0.3",
     "author": "Joyent (joyent.com)",
     "private": true,
     "repository": {

--- a/sapi_manifests/muskie/template
+++ b/sapi_manifests/muskie/template
@@ -38,6 +38,17 @@
     "maxTranslationCacheSize": 1000,
     "maxTranslationCacheAgeMs": 300000
   },
+  {{#SNAPLINK_CLEANUP_COMPLETE}}
+  "snaplinkCleanupComplete": true,
+  {{/SNAPLINK_CLEANUP_COMPLETE}}
+  {{^SNAPLINK_CLEANUP_COMPLETE}}
+  "snaplinkCleanupComplete": false,
+  {{/SNAPLINK_CLEANUP_COMPLETE}}
+  "accountsSnaplinksDisabled": [ {{#ACCOUNTS_SNAPLINKS_DISABLED}}
+    {
+      "uuid": "{{uuid}}"
+    }{{^last}},{{/last}}{{/ACCOUNTS_SNAPLINKS_DISABLED}}
+  ],
   "moray": {
     "morayOptions": {
         "srvDomain": "{{ELECTRIC_MORAY}}",

--- a/sapi_manifests/muskie/template
+++ b/sapi_manifests/muskie/template
@@ -38,12 +38,9 @@
     "maxTranslationCacheSize": 1000,
     "maxTranslationCacheAgeMs": 300000
   },
-  {{#SNAPLINK_CLEANUP_COMPLETE}}
-  "snaplinkCleanupComplete": true,
-  {{/SNAPLINK_CLEANUP_COMPLETE}}
-  {{^SNAPLINK_CLEANUP_COMPLETE}}
-  "snaplinkCleanupComplete": false,
-  {{/SNAPLINK_CLEANUP_COMPLETE}}
+  {{#SNAPLINK_CLEANUP_REQUIRED}}
+  "snaplinkCleanupRequired": true,
+  {{/SNAPLINK_CLEANUP_REQUIRED}}
   "accountsSnaplinksDisabled": [ {{#ACCOUNTS_SNAPLINKS_DISABLED}}
     {
       "uuid": "{{uuid}}"

--- a/sapi_manifests/muskie/template
+++ b/sapi_manifests/muskie/template
@@ -38,11 +38,6 @@
     "maxTranslationCacheSize": 1000,
     "maxTranslationCacheAgeMs": 300000
   },
-  "accountsSnaplinksDisabled": [ {{#ACCOUNTS_SNAPLINKS_DISABLED}}
-    {
-      "uuid": "{{uuid}}"
-    }{{^last}},{{/last}}{{/ACCOUNTS_SNAPLINKS_DISABLED}}
-  ],
   "moray": {
     "morayOptions": {
         "srvDomain": "{{ELECTRIC_MORAY}}",

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var util = require('util');
@@ -147,7 +147,6 @@ before(function (cb) {
     this.root = '/' + this.client.user + '/stor';
     this.dir = this.root + '/' + uuid.v4();
     this.key = this.dir + '/' + uuid.v4();
-    this.link = '/' + this.client.user + '/public/' + uuid.v4();
 
     self.client.mkdir(self.dir, function (err2) {
         if (err2) {
@@ -161,7 +160,7 @@ before(function (cb) {
                 return;
             }
 
-            self.client.ln(self.key, self.link, cb);
+            cb();
         });
     });
 });
@@ -170,9 +169,7 @@ before(function (cb) {
 after(function (cb) {
     var self = this;
     this.client.rmr(this.dir, function (err) {
-        self.client.unlink(self.link, function (err2) {
-            cb(err || err2);
-        });
+        cb(err);
     });
 });
 
@@ -507,31 +504,6 @@ test('create auth token ok', function (t) {
     });
 });
 
-
-test('anonymous get', function (t) {
-    this.rawClient.get(this.link, function (err, req) {
-        t.ifError(err);
-        if (err) {
-            t.end();
-            return;
-        }
-
-        req.once('result', function (err2, res) {
-            t.ifError(err2);
-
-            var body = '';
-            res.setEncoding('utf8');
-            res.on('data', function (chunk) {
-                body += chunk;
-            });
-
-            res.on('end', function () {
-                t.ok(body);
-                t.end();
-            });
-        });
-    });
-});
 
 
 test('anonymous get 403', function (t) {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -168,7 +168,8 @@ before(function (cb) {
 
 after(function (cb) {
     var self = this;
-    this.client.rmr(this.dir, function (err) {
+
+    self.client.rmr(self.dir, function (err) {
         cb(err);
     });
 });

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 var crypto = require('crypto');
@@ -121,80 +121,9 @@ after(function (cb) {
 
 test('put link', function (t) {
     this.client.ln(this.obj, this.key, function (err, res) {
-        t.ifError(err);
-        t.checkResponse(res, 204);
-        t.end();
-    });
-});
-
-
-test('link to public', function (t) {
-    this.client.ln(this.pubKey, this.key, function (err, res) {
-        t.ifError(err);
-        t.checkResponse(res, 204);
-        t.end();
-    });
-});
-
-
-test('put link parent ENOEXIST', function (t) {
-    var k = this.key + '/' + uuid.v4();
-    this.client.ln(this.obj, k, function (err, res) {
-        t.ok(err);
-        t.equal(err.name, 'DirectoryDoesNotExistError');
-        t.checkResponse(res, 404);
-        t.end();
-    });
-});
-
-
-test('put parent not directory', function (t) {
-    var k = this.obj + '/' + uuid.v4();
-    this.client.ln(this.obj, k, function (err, res) {
-        t.ok(err);
-        t.equal(err.name, 'ParentNotDirectoryError');
-        t.checkResponse(res, 400);
-        t.end();
-    });
-});
-
-
-test('put source not found', function (t) {
-    var src = this.dir + '/' + uuid.v4();
-    this.client.ln(src, this.key, function (err, res) {
-        t.ok(err);
-        t.equal(err.name, 'SourceObjectNotFoundError');
-        t.checkResponse(res, 404);
-        t.end();
-    });
-});
-
-
-test('put if-match', function (t) {
-    var self = this;
-    var opts = {
-        headers: {
-            'if-match': self.etag
-        }
-    };
-    this.client.ln(this.obj, this.key, opts, function (err, res) {
-        t.ifError(err);
-        t.checkResponse(res, 204);
-        t.end();
-    });
-});
-
-
-test('put if-match fail', function (t) {
-    var opts = {
-        headers: {
-            'if-match': uuid.v4()
-        }
-    };
-    this.client.ln(this.obj, this.key, opts, function (err, res) {
-        t.ok(err);
-        t.equal(err.name, 'PreconditionFailedError');
-        t.checkResponse(res, 412);
+        t.ok(err && err.code === 'SnaplinksDisabledError',
+            'Expected SnapLinks to be disabled');
+        t.checkResponse(res, 403);
         t.end();
     });
 });


### PR DESCRIPTION
This removes support for new SnapLinks and adds support for setting a flag SNAPLINK_CLEANUP_REQUIRED in SAPI to indicate that SnapLinks might still exist. When that flag is not set, it will be assumed there are no SnapLinks and all deletes can go to the `manta_fastdelete_queue`.