### PR TITLE
joyent/manta-muskie#35 want ability to use "referer" header in RBAC rules

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -999,7 +999,8 @@ function gatherContext(req, res, next) {
     if (ip) {
         conditions.sourceip = ip.split(',')[0].trim();
     }
-    conditions['user-agent'] = req.headers['user-agent'];
+    conditions['referer'] = req.headers['referer'] || '';
+    conditions['user-agent'] = req.headers['user-agent'] || '';
     conditions.fromjob = false;
 
     // Override conditions with ones that are provided in the token


### PR DESCRIPTION
Also:

joyent/manta-muskie#34 using user-agent in RBAC rules can lead to 500 errors

There aren't any auto-tests for RBAC conditions in muskie at all, so I'm not entirely sure how much to add for this.