### PR TITLE
MANTA-1936 Rip out syslog logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/trentm/restdown.git
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = https://github.com/davepacheco/javascriptlint.git
+	url = https://github.com/joyent/javascriptlint.git
 [submodule "deps/manta-scripts"]
 	path = deps/manta-scripts
 	url = https://github.com/joyent/manta-scripts.git

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,6 @@ JSSTYLE_FLAGS =		-f tools/jsstyle.conf
 
 SMF_MANIFESTS_IN =	smf/manifests/muskie.xml.in \
 			smf/manifests/haproxy.xml.in
-SHELL=/bin/bash
-
 
 #
 # Variables

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ JSSTYLE_FLAGS =		-f tools/jsstyle.conf
 
 SMF_MANIFESTS_IN =	smf/manifests/muskie.xml.in \
 			smf/manifests/haproxy.xml.in
+SHELL=/bin/bash
+
 
 #
 # Variables

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -158,7 +158,7 @@ wait_for_resolv_conf
 manta_setup_muskie
 manta_common2_setup_log_rotation 'muskie'
 
-manta_common_setup_end
+manta_common2_setup_end
 
 # Setup the mlocate alias
 echo "alias mlocate='/opt/smartdc/muskie/bin/mlocate -f /opt/smartdc/muskie/etc/config.json'" >> $PROFILE

--- a/etc/config.coal.json
+++ b/etc/config.coal.json
@@ -1,11 +1,7 @@
 {
     "clearProxyPort": 9080,
     "bunyan": {
-        "level": "info",
-        "syslog": {
-            "facility": "local0",
-            "type": "udp"
-        }
+        "level": "info"
     },
     "throttle": {
         "enabled": false,

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -13,7 +13,6 @@ var fs = require('fs');
 var artedi = require('artedi');
 var assert = require('assert-plus');
 var bunyan = require('bunyan');
-var bsyslog = require('bunyan-syslog');
 var LRU = require('lru-cache');
 var restify = require('restify');
 
@@ -161,115 +160,62 @@ function configure(appName, opts, dtProbes) {
  * @returns {Object} A bunyan logger object
  */
 function configureLogging(appName, bunyanCfg, verbose) {
+    assert.optionalObject(bunyanCfg, 'config.bunyan');
+
     var level;
     if (bunyanCfg) {
-        level = process.env.LOG_LEVEL || bunyanCfg.level || 'info';
+        assert.optionalString(bunyanCfg.level, 'config.bunyan.level');
+
+        level = bunyan.resolveLevel(process.env.LOG_LEVEL ||
+                    bunyanCfg.level || 'info');
     } else {
-        level = process.env.LOG_LEVEL || 'info';
+        level = bunyan.resolveLevel(process.env.LOG_LEVEL || 'info');
     }
-    var log = bunyan.createLogger({
-        name: appName,
-        streams: [ {
+
+    if (verbose) {
+        level = Math.max(bunyan.TRACE, (level - verbose.length * 10));
+    }
+
+    var streams = [];
+
+    streams.push({
             level: level,
             stream: process.stderr
-        } ],
+    });
+
+    if (level >= bunyan.INFO) {
+        /*
+         * We want debug info IFF the request fails AND the configured
+         * log level is info or higher.
+         */
+        const RequestCaptureStream = restify.bunyan.RequestCaptureStream;
+        streams.push({
+            level: 'debug',
+            type: 'raw',
+            stream: new RequestCaptureStream({
+                level: bunyan.WARN,
+                maxRecords: 2000,
+                maxRequestIds: 2000,
+                stream: process.stderr
+            })
+        });
+    }
+
+    var log = bunyan.createLogger({
+        name: appName,
+        streams: streams,
         serializers: restify.bunyan.serializers
     });
 
-    level = log.level();
-
     /*
-     * This is ugly, but we set this up so that if muskie is invoked with a
-     * -v flag, then we know you're running locally, and you just want the
-     * messages to spew to stderr. Otherwise, it's "production", and muskie
-     * likely logs to a syslog endpoint.
-     */
-    if (verbose || !bunyanCfg) {
-        if (verbose) {
-            level = Math.max(bunyan.TRACE, (log.level() - verbose.length * 10));
-            log.level(level);
-        }
-
-        /*
-         * If the configured logging level is at or below DEBUG then enable
-         * source logging.
-         */
-        if (level <= bunyan.DEBUG) {
-            log = log.child({src: true});
-        }
-
-        return (log);
-    }
-
-    assert.object(bunyanCfg, 'config.bunyan');
-    assert.optionalString(bunyanCfg.level, 'config.bunyan.level');
-    assert.optionalObject(bunyanCfg.syslog, 'config.bunyan.syslog');
-
-    level = bunyan.resolveLevel(process.env.LOG_LEVEL ||
-                                bunyanCfg.level ||
-                                'info');
-
-    log.debug('Bunyan log level: ' + level);
-
-    if (bunyanCfg.syslog) {
-        var streams = [];
-        var sysl;
-
-        assert.string(bunyanCfg.syslog.facility,
-                      'config.bunyan.syslog.facility');
-        assert.string(bunyanCfg.syslog.type, 'config.bunyan.syslog.type');
-
-        sysl = bsyslog.createBunyanStream({
-            facility: bsyslog.facility[bunyanCfg.syslog.facility],
-            name: appName,
-            host: bunyanCfg.syslog.host,
-            port: bunyanCfg.syslog.port,
-            type: bunyanCfg.syslog.type
-        });
-
-        streams.push({
-            level: level,
-            stream: sysl
-        });
-
-        /*
-         * We want debug info only IFF the request fails AND the configured
-         * log level is info or higher.
-         */
-        if (level >= bunyan.INFO) {
-            const RequestCaptureStream = restify.bunyan.RequestCaptureStream;
-            streams.push({
-                level: 'debug',
-                type: 'raw',
-                stream: new RequestCaptureStream({
-                    level: bunyan.WARN,
-                    maxRecords: 2000,
-                    maxRequestIds: 2000,
-                    streams: [ {
-                        raw: true,
-                        stream: sysl
-                    }]
-                })
-            });
-        }
-
-        log = bunyan.createLogger({
-            name: appName,
-            level: level,
-            streams: streams,
-            serializers: restify.bunyan.serializers
-        });
-    } else {
-        log.level(level);
-    }
-
-    /*
-     * If the configured logging level is at or below DEBUG then enable source
-     * logging.
+     * If the configured logging level is at or below DEBUG then enable
+     * source logging.
      */
     if (level <= bunyan.DEBUG) {
         log = log.child({src: true});
     }
+
+    log.debug('bunyan log level: ' + level);
 
     return (log);
 }

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -152,11 +152,10 @@ function configure(appName, opts, dtProbes) {
  * Configure the logger based on the configuration data
  *
  * @param {String} appName: Required. The name of the application
- * @param {Object} bunyanCfg: Required. The bunyan configuration data
- * @param {arrayOfBool} verbose: Required. Array of boolean values that
+ * @param {Object} bunyanCfg: Optional. The bunyan configuration data
+ * @param {arrayOfBool} verbose: Optional. Array of boolean values that
  * indicates if verbose logging should be enabled and the level of verbosity
- * requested. Used to determine if syslog logging should be configured or not
- * and to set the logging level appropriately.
+ * requested.
  * @returns {Object} A bunyan logger object
  */
 function configureLogging(appName, bunyanCfg, verbose) {

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var net = require('net');
@@ -14,7 +14,6 @@ var path = require('path');
 
 var apertureConfig = require('aperture-config').config;
 var assert = require('assert-plus');
-var bsyslog = require('bunyan-syslog');
 var bunyan = require('bunyan');
 var cueball = require('cueball');
 var dashdash = require('dashdash');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "assert-plus": "0.1.5",
         "backoff": "2.3.0",
         "bunyan": "0.22.1",
-        "bunyan-syslog": "0.2.2",
         "cmdln": "4.3.0",
         "content-disposition": "0.5.3",
         "cueball": "2.2.9",

--- a/sapi_manifests/muskie/template
+++ b/sapi_manifests/muskie/template
@@ -1,11 +1,7 @@
 {
   "clearProxyPort": 81,
   "bunyan": {
-    "level": "info",
-    "syslog": {
-      "facility": "local0",
-      "type": "udp"
-    }
+    "level": "info"
   },
   "throttle": {
     {{#MUSKIE_THROTTLE_ENABLED}}

--- a/test/configure.test.js
+++ b/test/configure.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var bunyan = require('bunyan');
@@ -14,25 +14,9 @@ var configure = require('../lib/configure.js');
 exports.configureLogging = function (t) {
     var appName = 'muskie';
     var bunyanCfg1 = {
-        level: 'info',
-        syslog: {
-            facility: 'local0',
-            type: 'udp'
-        }
-    };
-    var bunyanCfg2 = {
-        level: 'debug',
-        syslog: {
-            facility: 'local0',
-            type: 'udp'
-        }
-    };
-
-    var bunyanCfg3 = {
         level: 'info'
     };
-
-    var bunyanCfg4 = {
+    var bunyanCfg2 = {
         level: 'debug'
     };
 
@@ -91,36 +75,13 @@ exports.configureLogging = function (t) {
     t.equal(logObj7.level(), bunyan.TRACE);
     t.equal(logObj7.src, true);
 
-    process.env.LOG_LEVEL = '';
-    var logObj8 = configure.configureLogging(appName, bunyanCfg3, null);
-
-    t.equal(logObj8.streams.length, 1);
-    t.equal(logObj8.level(), bunyan.INFO);
-    t.equal(logObj8.src, false);
-
-    var logObj9 = configure.configureLogging(appName, bunyanCfg3, [true]);
-
-    t.equal(logObj9.streams.length, 1);
-    t.equal(logObj9.level(), bunyan.DEBUG);
-    t.equal(logObj9.src, true);
-
-    var logObj10 = configure.configureLogging(appName, bunyanCfg4, null);
-
-    t.equal(logObj10.streams.length, 1);
-    t.equal(logObj10.level(), bunyan.DEBUG);
-    t.equal(logObj10.src, true);
-
-    var logObj11 = configure.configureLogging(appName, bunyanCfg4, [true]);
-
-    t.equal(logObj11.streams.length, 1);
-    t.equal(logObj11.level(), bunyan.TRACE);
-    t.equal(logObj11.src, true);
-
     process.env.LOG_LEVEL = 'info';
     var logObj12 = configure.configureLogging(appName, null, null);
 
-    t.equal(logObj12.streams.length, 1);
-    t.equal(logObj12.level(), bunyan.INFO);
+    t.equal(logObj12.streams.length, 2);
+    var logObject12Levels = logObj12.levels().sort();
+    t.equal(logObject12Levels[0], bunyan.DEBUG);
+    t.equal(logObject12Levels[1], bunyan.INFO);
     t.equal(logObj12.src, false);
 
     var logObj13 = configure.configureLogging(appName, null, [true]);


### PR DESCRIPTION
Testing notes:

I built this image and ran it on my lab setup and verified it work.  All of the logs were correctly sent to the SMF logging location (`svcs -L muskie-8081`) and no logging was sent to `/var/log`