### PR TITLE
Revert "MANTA-5150 webapi should abort on uncaught exceptions (#59)"

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -121,7 +121,6 @@ function createServer(options, clients, name) {
     };
     options.noWriteContinue = true;
     options.handleUpgrades = true;
-    options.handleUncaughtExceptions = false;
 
     var log = options.log.child({
         component: 'HttpServer'

--- a/main.js
+++ b/main.js
@@ -115,10 +115,7 @@ function createMonitoringServer(cfg) {
     kangOpts = cueball.poolMonitor.toKangOptions();
     port = cfg.port + 800;
 
-    monitorServer = restify.createServer({
-        serverName: 'Monitor',
-        handleUncaughtExceptions: false
-    });
+    monitorServer = restify.createServer({ serverName: 'Monitor' });
     monitorServer.get('/metrics', app.getMetricsHandler(cfg.collector));
     monitorServer.get(new RegExp('.*'), kang.knRestifyHandler(kangOpts));
 


### PR DESCRIPTION
This reverts commit d0cb3275577130b3fa52481b5d7ba31d6dbd22f6.
This causes MANTA-5152: domains issues in check_stream.js