### PR TITLE
MANTA-5132 put back MPU (revert the removal of MPU-related tests)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,17 @@ ENGBLD_REQUIRE		:= $(shell git submodule update --init deps/eng)
 include ./deps/eng/tools/mk/Makefile.defs
 TOP ?= $(error Unable to access eng.git submodule Makefiles.)
 
-include ./deps/eng/tools/mk/Makefile.node_prebuilt.defs
-include ./deps/eng/tools/mk/Makefile.agent_prebuilt.defs
 include ./deps/eng/tools/mk/Makefile.node_modules.defs
-include ./deps/eng/tools/mk/Makefile.smf.defs
+ifeq ($(shell uname -s),SunOS)
+	include ./deps/eng/tools/mk/Makefile.node_prebuilt.defs
+	include ./deps/eng/tools/mk/Makefile.agent_prebuilt.defs
+	include ./deps/eng/tools/mk/Makefile.smf.defs
+else
+	NPM=npm
+	NODE=node
+	NPM_EXEC=$(shell which npm)
+	NODE_EXEC=$(shell which node)
+endif
 
 RELEASE_TARBALL :=	$(NAME)-pkg-$(STAMP).tar.gz
 ROOT :=			$(shell pwd)
@@ -145,8 +152,10 @@ python2-symlink:
 	fi
 
 include ./deps/eng/tools/mk/Makefile.deps
-include ./deps/eng/tools/mk/Makefile.node_prebuilt.targ
-include ./deps/eng/tools/mk/Makefile.agent_prebuilt.targ
+ifeq ($(shell uname -s),SunOS)
+	include ./deps/eng/tools/mk/Makefile.node_prebuilt.targ
+	include ./deps/eng/tools/mk/Makefile.agent_prebuilt.targ
+	include ./deps/eng/tools/mk/Makefile.smf.targ
+endif
 include ./deps/eng/tools/mk/Makefile.node_modules.targ
-include ./deps/eng/tools/mk/Makefile.smf.targ
 include ./deps/eng/tools/mk/Makefile.targ

--- a/test/dir.test.js
+++ b/test/dir.test.js
@@ -170,7 +170,7 @@ function testListWithParams(t, params) {
     var subdirs = [];
     var count = 5;
     var i;
-    for (i = 0; i < ount; i++) {
+    for (i = 0; i < count; i++) {
         subdirs.push(self.dir + '/' + uuid.v4());
     }
     subdirs = subdirs.sort();

--- a/test/dir.test.js
+++ b/test/dir.test.js
@@ -170,7 +170,7 @@ function testListWithParams(t, params) {
     var subdirs = [];
     var count = 5;
     var i;
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < ount; i++) {
         subdirs.push(self.dir + '/' + uuid.v4());
     }
     subdirs = subdirs.sort();
@@ -244,6 +244,7 @@ before(function (cb) {
     this.operatorClient = helper.createOperatorClient();
     this.top = '/' + this.client.user;
     this.root = this.top + '/stor';
+    this.mpuRoot = this.top + '/uploads';
     this.dir = this.root + '/' + uuid.v4();
     this.key = this.dir + '/' + uuid.v4();
     this.client.mkdir(this.dir, cb);
@@ -507,7 +508,7 @@ test('ls top', function (t) {
             t.ok(http_res);
             t.checkResponse(http_res, 200);
             t.equal(0, objs.length);
-
+            t.equal(4, dirs.length);
             var names = dirs.map(function (d) {
                 return (d.name);
             }).filter(function (d) {
@@ -516,7 +517,6 @@ test('ls top', function (t) {
                 }
                 return (true);
             }).sort();
-
             t.deepEqual(names, ['public', 'reports', 'stor']);
             t.end();
         });
@@ -551,7 +551,7 @@ test('ls top with marker', function (t) {
             t.ok(http_res);
             t.checkResponse(http_res, 200);
             t.equal(0, objs.length);
-
+            t.equal(3, dirs.length);
             var names = dirs.map(function (d) {
                 return (d.name);
             }).filter(function (d) {
@@ -560,8 +560,7 @@ test('ls top with marker', function (t) {
                 }
                 return (true);
             }).sort();
-
-            t.deepEqual(names, ['reports', 'stor']);
+            t.deepEqual(['reports', 'stor'], names);
             t.end();
         });
     });
@@ -570,6 +569,16 @@ test('ls top with marker', function (t) {
 
 test('rmdir top', function (t) {
     this.client.unlink(this.top, function (err, res) {
+        t.ok(err);
+        t.ok(res);
+        t.equal(err.name, 'OperationNotAllowedOnRootDirectoryError');
+        t.checkResponse(res, 400);
+        t.end();
+    });
+});
+
+test('rmdir mpuRoot', function (t) {
+    this.client.unlink(this.mpuRoot, function (err, res) {
         t.ok(err);
         t.ok(res);
         t.equal(err.name, 'OperationNotAllowedOnRootDirectoryError');

--- a/test/dir.test.js
+++ b/test/dir.test.js
@@ -24,6 +24,7 @@ var after = helper.after;
 var before = helper.before;
 var test = helper.test;
 
+var mpuEnabled = Boolean(require('../etc/config.json').enableMPU);
 
 
 ///--- Helpers
@@ -244,7 +245,9 @@ before(function (cb) {
     this.operatorClient = helper.createOperatorClient();
     this.top = '/' + this.client.user;
     this.root = this.top + '/stor';
-    this.mpuRoot = this.top + '/uploads';
+    if (mpuEnabled) {
+        this.mpuRoot = this.top + '/uploads';
+    }
     this.dir = this.root + '/' + uuid.v4();
     this.key = this.dir + '/' + uuid.v4();
     this.client.mkdir(this.dir, cb);
@@ -507,8 +510,8 @@ test('ls top', function (t) {
         res.once('end', function (http_res) {
             t.ok(http_res);
             t.checkResponse(http_res, 200);
-            t.equal(0, objs.length);
-            t.equal(4, dirs.length);
+            t.equal(0, objs.length,
+                'zero *objects* at top level `ls /:login`: objs=' + objs);
             var names = dirs.map(function (d) {
                 return (d.name);
             }).filter(function (d) {
@@ -551,7 +554,6 @@ test('ls top with marker', function (t) {
             t.ok(http_res);
             t.checkResponse(http_res, 200);
             t.equal(0, objs.length);
-            t.equal(3, dirs.length);
             var names = dirs.map(function (d) {
                 return (d.name);
             }).filter(function (d) {
@@ -577,15 +579,17 @@ test('rmdir top', function (t) {
     });
 });
 
-test('rmdir mpuRoot', function (t) {
-    this.client.unlink(this.mpuRoot, function (err, res) {
-        t.ok(err);
-        t.ok(res);
-        t.equal(err.name, 'OperationNotAllowedOnRootDirectoryError');
-        t.checkResponse(res, 400);
-        t.end();
+if (mpuEnabled) {
+    test('rmdir mpuRoot', function (t) {
+        this.client.unlink(this.mpuRoot, function (err, res) {
+            t.ok(err);
+            t.ok(res);
+            t.equal(err.name, 'OperationNotAllowedOnRootDirectoryError');
+            t.checkResponse(res, 400);
+            t.end();
+        });
     });
-});
+}
 
 test('mkdir root', function (t) {
     this.client.mkdir(this.root, function (err, res) {

--- a/test/mpu/abort.test.js
+++ b/test/mpu/abort.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var uuid = require('node-uuid');

--- a/test/mpu/abort.test.js
+++ b/test/mpu/abort.test.js
@@ -29,6 +29,8 @@ var computePartsMD5 = helper.computePartsMD5;
 var createPartOptions = helper.createPartOptions;
 var writeObject = helper.writeObject;
 
+var mpuEnabled = Boolean(require('../../etc/config.json').enableMPU);
+if (mpuEnabled) {
 
 before(function (cb) {
     helper.initMPUTester.call(this, cb);
@@ -192,3 +194,5 @@ test('abort upload: non-existent id', function (t) {
         t.end();
     });
 });
+
+} // mpuEnabled

--- a/test/mpu/abort.test.js
+++ b/test/mpu/abort.test.js
@@ -1,0 +1,194 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2017, Joyent, Inc.
+ */
+
+var uuid = require('node-uuid');
+var path = require('path');
+var vasync = require('vasync');
+var verror = require('verror');
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+if (require.cache[__dirname + '/helper.js'])
+    delete require.cache[__dirname + '/helper.js'];
+var testHelper = require('../helper.js');
+var helper = require('./helper.js');
+
+var after = testHelper.after;
+var before = testHelper.before;
+var test = testHelper.test;
+
+var ifErr = helper.ifErr;
+var computePartsMD5 = helper.computePartsMD5;
+var createPartOptions = helper.createPartOptions;
+var writeObject = helper.writeObject;
+
+
+before(function (cb) {
+    helper.initMPUTester.call(this, cb);
+});
+
+
+after(function (cb) {
+    helper.cleanupMPUTester.call(this, cb);
+});
+
+
+test('abort upload', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.abortUpload(self.uploadId, function (err2) {
+            if (ifErr(t, err2, 'aborted upload')) {
+                t.end();
+                return;
+            }
+
+            self.getUpload(self.uploadId, function (err3, upload) {
+                if (ifErr(t, err3, 'got upload')) {
+                    t.end();
+                    return;
+                }
+
+                t.deepEqual(upload.headers, {});
+                t.equal(upload.state, 'done');
+                t.equal(upload.result, 'aborted');
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('abort upload: upload already aborted', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.abortUpload(self.uploadId, function (err2) {
+            if (ifErr(t, err2, 'aborted upload')) {
+                t.end();
+                return;
+            }
+
+            self.abortUpload(self.uploadId, function (err3) {
+                if (ifErr(t, err, 'aborted upload')) {
+                    t.end();
+                    return;
+                }
+
+                self.getUpload(self.uploadId, function (err4, upload) {
+                    if (ifErr(t, err, 'got upload')) {
+                        t.end();
+                        return;
+                    }
+
+                    t.deepEqual(upload.headers, {});
+                    t.equal(upload.state, 'done');
+                    t.equal(upload.result, 'aborted');
+                    t.end();
+                });
+            });
+        });
+    });
+});
+
+
+// Abort: bad input
+
+test('abort upload: upload already committed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err2) {
+            if (ifErr(t, err2, 'commited upload')) {
+                t.end();
+                return;
+            }
+
+            self.abortUpload(self.uploadId, function (err3) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+                }
+                t.ok(verror.hasCauseWithName(err3,
+                    'InvalidMultipartUploadStateError'), err);
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('abort upload: non-uuid id', function (t) {
+    var self = this;
+    var bogus = 'foobar';
+    var action = 'abort';
+
+    var options = {
+        headers: {
+            'content-type': 'application/json',
+            'expect': 'application/json'
+        },
+        path: '/' + this.client.user + '/uploads/f/' + bogus + '/' + action
+    };
+
+    self.client.signRequest({
+        headers: options.headers
+    },
+    function (err) {
+        if (ifErr(t, err, 'sign request')) {
+            t.end();
+            return;
+        }
+
+        // We use the jsonClient directly, or we will blow a non-uuid assert
+        // in the Manta client.
+        self.client.jsonClient.post(options, {}, function (err2, _, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+
+            t.checkResponse(res, 404);
+            t.ok(verror.hasCauseWithName(err2, 'ResourceNotFoundError'));
+            t.end();
+        });
+    });
+});
+
+
+test('abort upload: non-existent id', function (t) {
+    var self = this;
+    var bogus = uuid.v4();
+    self.uploadId = bogus;
+
+    self.getUpload(bogus, function (err, upload) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err, 'ResourceNotFoundError'), err);
+        t.end();
+    });
+});

--- a/test/mpu/auth.test.js
+++ b/test/mpu/auth.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var crypto = require('crypto');

--- a/test/mpu/auth.test.js
+++ b/test/mpu/auth.test.js
@@ -28,6 +28,9 @@ var ifErr = helper.ifErr;
 var computePartsMD5 = helper.computePartsMD5;
 
 
+var mpuEnabled = Boolean(require('../../etc/config.json').enableMPU);
+if (mpuEnabled) {
+
 before(function (cb) {
     helper.initMPUTester.call(this, cb);
 });
@@ -714,3 +717,5 @@ test('DELETE /:account/uploads/[0-f]/:id/:partNum disallowed', function (t) {
         });
     });
 });
+
+} // mpuEnabled

--- a/test/mpu/auth.test.js
+++ b/test/mpu/auth.test.js
@@ -1,0 +1,716 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2017, Joyent, Inc.
+ */
+
+var crypto = require('crypto');
+var MemoryStream = require('stream').PassThrough;
+var path = require('path');
+var verror = require('verror');
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+if (require.cache[__dirname + '/helper.js'])
+    delete require.cache[__dirname + '/helper.js'];
+var testHelper = require('../helper.js');
+var helper = require('./helper.js');
+
+var after = testHelper.after;
+var before = testHelper.before;
+var test = testHelper.test;
+
+var ifErr = helper.ifErr;
+var computePartsMD5 = helper.computePartsMD5;
+
+
+before(function (cb) {
+    helper.initMPUTester.call(this, cb);
+});
+
+
+after(function (cb) {
+    helper.cleanupMPUTester.call(this, cb);
+});
+
+
+// Subusers (not supported for MPU API)
+
+// Create
+test('subusers disallowed: create', function (t) {
+    var self = this;
+    self.createUploadSubuser(self.path, {}, function (err) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'AuthorizationFailedError'), err);
+        t.end();
+    });
+});
+
+// Get
+test('subusers disallowed: get upload under same account', function (t) {
+    var self = this;
+    self.createUpload(self.path, {}, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.getUploadSubuser(self.uploadId, function (err2, upload) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2, 'AuthorizationFailedError'),
+                err2);
+            t.end();
+        });
+    });
+});
+
+
+// Upload
+test('subusers disallowed: upload part', function (t) {
+    var self = this;
+    self.createUpload(self.path, {}, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.randomPartNum();
+        self.writeTestObjectSubuser(self.uploadId, pn, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2, 'NoMatchingRoleTagError'),
+                err2);
+            t.end();
+        });
+    });
+});
+
+
+// Abort
+test('subusers disallowed: abort', function (t) {
+    var self = this;
+    self.createUpload(self.path, {}, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.abortUploadSubuser(self.uploadId, function (err2) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2, 'AuthorizationFailedError'),
+                err2);
+            t.end();
+        });
+    });
+});
+
+
+// Commit
+test('subusers disallowed: commit', function (t) {
+    var self = this;
+    self.createUpload(self.path, {}, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUploadSubuser(self.uploadId, [], function (err2) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2, 'AuthorizationFailedError'),
+                err2);
+            t.end();
+        });
+    });
+});
+
+
+// Redirect
+test('subusers disallowed: redirect (GET /:account/uploads/:id)', function (t) {
+    var self = this;
+    self.createUpload(self.path, {}, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+
+        self.userClient.get(self.redirectPath(), opts, function (err2) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2, 'AuthorizationFailedError'),
+                err2);
+            t.end();
+        });
+    });
+});
+
+
+test('subusers disallowed: redirect (GET /:account/uploads/:id/:partNum)',
+function (t) {
+    var self = this;
+    self.createUpload(self.path, {}, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+
+        var pn = 0;
+        self.userClient.get(self.redirectPath(pn), opts, function (err2) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2, 'AuthorizationFailedError'),
+                err2);
+            t.end();
+        });
+    });
+});
+
+
+// Forbidden routes
+test('PUT /:account/uploads disallowed', function (t) {
+    var self = this;
+    var a = self.client.user;
+    var p = '/' + a + '/uploads';
+
+    var string = 'foobar';
+    var opts = {
+        account: a,
+        md5: crypto.createHash('md5').update(string).digest('base64'),
+        size: Buffer.byteLength(string),
+        type: 'text/plain'
+    };
+    var stream = new MemoryStream();
+    setImmediate(stream.end.bind(stream, string));
+    self.client.put(p, stream, opts, function (err, res) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.checkResponse(res, 400);
+        t.ok(verror.hasCauseWithName(err,
+            'OperationNotAllowedOnRootDirectoryError'), err);
+        t.end();
+    });
+});
+
+
+test('POST /:account/uploads/[0-f]/:id disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            headers: {
+                'content-type': 'application/json',
+                'expect': 'application/json'
+            },
+            path: self.uploadPath()
+        };
+
+        self.client.signRequest({
+            headers: opts.headers
+        }, function (err2) {
+            if (ifErr(t, err2, 'write test object')) {
+                t.end();
+                return;
+            }
+
+            self.client.jsonClient.post(opts, {}, function (err3, _, res) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+            }
+                t.checkResponse(res, 405);
+                t.ok(verror.hasCauseWithName(err3, 'MethodNotAllowedError'),
+                    err3);
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('DELETE /:account/uploads/[0-f]/:id disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.client.unlink(self.uploadPath(), function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('HEAD /:account/uploads/[0-f]/:id/state disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'state';
+        var p = self.uploadPath() + '/' + action;
+        self.client.info(p, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('PUT /:account/uploads/[0-f]/:id/state disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'state';
+        var p = self.uploadPath() + '/' + action;
+        var s = new MemoryStream();
+        var opts = {
+            size: 0
+        };
+        setImmediate(s.end.bind(s));
+
+       self.client.put(p, s, opts, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            // For PUTS, muskie interprets "state" as the partNum
+            t.checkResponse(res, 409);
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('POST /:account/uploads/[0-f]/:id/state disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'state';
+        var p = self.uploadPath() + '/' + action;
+        var opts = {
+            headers: {
+                'content-type': 'application/json',
+                'expect': 'application/json'
+            },
+            path: p
+        };
+
+        self.client.signRequest({
+            headers: opts.headers
+        }, function (err2) {
+            if (ifErr(t, err2, 'write test object')) {
+                t.end();
+                return;
+            }
+
+            self.client.jsonClient.post(opts, {}, function (err3, _, res) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+                }
+                t.checkResponse(res, 405);
+                t.ok(verror.hasCauseWithName(err3, 'MethodNotAllowedError'),
+                    err3);
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('DELETE /:account/uploads/[0-f]/:id/state disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'state';
+        var p = self.uploadPath() + '/' + action;
+        self.client.unlink(p, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('PUT /:account/uploads/[0-f]/:id/abort disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'abort';
+        var p = self.uploadPath() + '/' + action;
+        var s = new MemoryStream();
+        var opts = {
+            size: 0
+        };
+        setImmediate(s.end.bind(s));
+
+        self.client.put(p, s, opts, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            // For PUTS, muskie interprets "abort" as the partNum
+            t.checkResponse(res, 409);
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('GET /:account/uploads/[0-f]/:id/abort disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'abort';
+        var p = self.uploadPath() + '/' + action;
+        self.client.get(p, function (err2, _, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('HEAD /:account/uploads/[0-f]/:id/abort disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'abort';
+        var p = self.uploadPath() + '/' + action;
+        self.client.info(p, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('DELETE /:account/uploads/[0-f]/:id/abort disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'abort';
+        var p = self.uploadPath() + '/' + action;
+        self.client.unlink(p, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('GET /:account/uploads/[0-f]/:id/commit disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'commit';
+        var p = self.uploadPath() + '/' + action;
+        self.client.get(p, {}, function (err2, _, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('HEAD /:account/uploads/[0-f]/:id/commit disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'commit';
+        var p = self.uploadPath() + '/' + action;
+        self.client.info(p, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('PUT /:account/uploads/[0-f]/:id/commit disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'commit';
+        var p = self.uploadPath() + '/' + action;
+        var s = new MemoryStream();
+        var opts = {
+            size: 0
+        };
+        setImmediate(s.end.bind(s));
+
+        self.client.put(p, s, opts, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            // For PUTS, muskie interprets "commit" as the partNum
+            t.checkResponse(res, 409);
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('DELETE /:account/uploads/[0-f]/:id/commit disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var action = 'commit';
+        var p = self.uploadPath() + '/' + action;
+        self.client.unlink(p, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 405);
+            t.ok(verror.hasCauseWithName(err2, 'MethodNotAllowedError'), err2);
+            t.end();
+        });
+    });
+});
+
+
+test('GET /:account/uploads/[0-f]/:id/:partNum disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.randomPartNum();
+        self.writeTestObject(self.uploadId, pn, function (err2) {
+            self.client.get(self.uploadPath(pn), {}, function (err3, _, res) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+                }
+                t.checkResponse(res, 405);
+                t.ok(verror.hasCauseWithName(err3, 'MethodNotAllowedError'),
+                    err3);
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('POST /:account/uploads/[0-f]/:id/:partNum disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.randomPartNum();
+        self.writeTestObject(self.uploadId, pn, function (err2) {
+            if (ifErr(t, err2, 'write test object')) {
+                t.end();
+                return;
+            }
+
+            var opts = {
+                headers: {
+                    'content-type': 'application/json',
+                    'expect': 'application/json'
+                },
+                path: self.uploadPath(pn)
+            };
+
+            self.client.signRequest({
+                headers: opts.headers
+            }, function (err3) {
+                if (ifErr(t, err3, 'write test object')) {
+                    t.end();
+                    return;
+                }
+
+                self.client.jsonClient.post(opts, {}, function (err4, _, res) {
+                    t.ok(err4);
+                    if (!err4) {
+                        return (t.end());
+                    }
+                    t.checkResponse(res, 405);
+                    t.ok(verror.hasCauseWithName(err4, 'MethodNotAllowedError'),
+                        err4);
+                    t.end();
+                });
+            });
+        });
+    });
+});
+
+
+test('DELETE /:account/uploads/[0-f]/:id/:partNum disallowed', function (t) {
+    var self = this;
+
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.randomPartNum();
+        self.writeTestObject(self.uploadId, pn, function (err2) {
+            self.client.unlink(self.uploadPath(pn), function (err3, res) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+                }
+                t.checkResponse(res, 405);
+                t.ok(verror.hasCauseWithName(err3, 'MethodNotAllowedError'),
+                    err3);
+                t.end();
+            });
+        });
+    });
+});

--- a/test/mpu/commit.test.js
+++ b/test/mpu/commit.test.js
@@ -1,0 +1,842 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+var MemoryStream = require('stream').PassThrough;
+var uuid = require('node-uuid');
+var path = require('path');
+var vasync = require('vasync');
+var verror = require('verror');
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+if (require.cache[__dirname + '/helper.js'])
+    delete require.cache[__dirname + '/helper.js'];
+var testHelper = require('../helper.js');
+var helper = require('./helper.js');
+
+var after = testHelper.after;
+var before = testHelper.before;
+var test = testHelper.test;
+
+var ifErr = helper.ifErr;
+var computePartsMD5 = helper.computePartsMD5;
+
+
+before(function (cb) {
+    helper.initMPUTester.call(this, cb);
+});
+
+
+after(function (cb) {
+    helper.cleanupMPUTester.call(this, cb);
+});
+
+// Commit
+
+test('commit upload: zero parts', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err3) {
+            if (ifErr(t, err3, 'committed upload')) {
+                t.end();
+                return;
+            }
+
+            self.getUpload(self.uploadId, function (err4, upload) {
+                if (ifErr(t, err4, 'created upload')) {
+                    t.end();
+                    return;
+                }
+
+                t.deepEqual(upload.headers, {});
+                t.equal(upload.state, 'done');
+                t.equal(upload.result, 'committed');
+                t.equal(upload.partsMD5Summary, computePartsMD5([]));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('commit upload: one part', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            var etag = res.headers.etag;
+            self.commitUpload(self.uploadId, [etag], function (err3) {
+                if (ifErr(t, err3, 'committed upload')) {
+                    t.end();
+                    return;
+                }
+
+                self.getUpload(self.uploadId, function (err4, upload) {
+                    if (ifErr(t, err4, 'created upload')) {
+                        t.end();
+                        return;
+                    }
+
+                    t.deepEqual(upload.headers, {});
+                    t.equal(upload.state, 'done');
+                    t.equal(upload.result, 'committed');
+                    t.equal(upload.partsMD5Summary, computePartsMD5([etag]));
+                    t.end();
+                });
+            });
+        });
+    });
+});
+
+test('commit upload: commit content md5 match', function (t) {
+    var self = this;
+    vasync.waterfall([
+        function (callback) {
+            self.createUpload(self.path, null, function (err) {
+                if (ifErr(t, err, 'created upload')) {
+                    callback(err);
+                } else {
+                    callback(null);
+                }
+            });
+        },
+        function (callback) {
+            self.writeTestObject(self.uploadId, 0, function (err, res) {
+                if (ifErr(t, err, 'uploaded part')) {
+                    callback(err);
+                } else {
+                    t.ok(res);
+                    t.checkResponse(res, 204);
+                    callback(null, res.headers.etag);
+                }
+            });
+        },
+        function (etag, callback) {
+            self.commitUpload(self.uploadId, [etag], function (err, res) {
+                if (ifErr(t, err, 'commited upload')) {
+                    callback(err);
+                } else {
+                    t.ok(res);
+                    t.ok(res.headers);
+                    t.ok(res.headers['computed-md5']);
+                    if (res === undefined || res.headers == undefined) {
+                        callback(new Error('commit upload missing res'));
+                        return;
+                    }
+                    callback(null, res.headers['computed-md5']);
+                }
+            });
+        },
+        function (computedMd5, callback) {
+            self.client.info(self.path, function (err, info) {
+                if (ifErr(t, err, 'got object info')) {
+                    callback(err);
+                } else {
+                    t.ok(info, 'failed to get object info');
+                    if (info) {
+                        var headers = info.headers || {};
+                        t.equal(computedMd5, helper.TEXT_MD5);
+                        t.equal(computedMd5, headers['content-md5']);
+                    }
+                    callback(null);
+                }
+            });
+        }
+    ], function () {
+        t.end();
+    });
+});
+
+
+test('commit upload: already commited, same set of parts', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            var etag = res.headers.etag;
+            self.commitUpload(self.uploadId, [etag], function (err3) {
+                if (ifErr(t, err3, 'committed upload')) {
+                    t.end();
+                    return;
+                }
+
+                self.commitUpload(self.uploadId, [etag], function (err4) {
+                    if (ifErr(t, err4, 'committed upload')) {
+                        t.end();
+                        return;
+                    }
+
+                    self.getUpload(self.uploadId, function (err5, upload) {
+                        if (ifErr(t, err5, 'got upload')) {
+                            t.end();
+                            return;
+                        }
+
+                        t.deepEqual(upload.headers, {});
+                        t.equal(upload.state, 'done');
+                        t.equal(upload.result, 'committed');
+                        t.equal(upload.partsMD5Summary,
+                            computePartsMD5([etag]));
+                        t.end();
+                    });
+                });
+            });
+        });
+    });
+});
+
+
+test('commit upload: ensure etag exists on target object', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err2) {
+            if (ifErr(t, err2, 'committed upload')) {
+                t.end();
+                return;
+            }
+
+            self.client.info(self.path, function (err3, info1) {
+                if (ifErr(t, err3, 'HEAD target object')) {
+                    t.end();
+                    return;
+                }
+
+                t.ok(info1);
+                t.ok(info1.etag);
+
+                var s = new MemoryStream();
+                var string = 'foobar';
+                var opts = {
+                    size: string.length
+                };
+                setImmediate(s.end.bind(s, string));
+
+                self.client.put(self.path, s, opts, function (err4, res) {
+                    if (ifErr(t, err4, 'overwriting target object')) {
+                        t.end();
+                        return;
+                    }
+
+                    self.client.info(self.path, function (err5, info2) {
+                        if (ifErr(t, err5, 'HEAD overwritten target object')) {
+                            t.end();
+                            return;
+                        }
+
+                        t.ok(info2);
+                        t.ok(info2.etag);
+                        t.ok(info1.etag !== info2.etag);
+                        t.done();
+                    });
+                });
+            });
+        });
+    });
+});
+
+
+
+
+// Commit: invalid upload (not related to the JSON API inputs)
+
+test('commit upload: already aborted', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.abortUpload(self.uploadId, function (err2) {
+            if (ifErr(t, err2, 'created upload')) {
+                t.end();
+                return;
+            }
+
+            self.commitUpload(self.uploadId, [], function (err3) {
+                if (!err3) {
+                    t.fail('upload already aborted');
+                    t.end();
+                    return;
+                }
+
+                t.ok(verror.hasCauseWithName(err3,
+                    'InvalidMultipartUploadStateError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('commit upload: already committed, different set of parts', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            var etag = res.headers.etag;
+            self.commitUpload(self.uploadId, [etag, etag], function (err3) {
+                if (!err3) {
+                    t.fail('upload already committed with different part set');
+                    t.end();
+                    return;
+                }
+
+                t.ok(verror.hasCauseWithName(err3,
+                    'MultipartUploadInvalidArgumentError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('commit upload: object size does not match create header (0 parts)',
+function (t) {
+    var self = this;
+    var h = {
+        'content-length': helper.TEXT.length
+    };
+
+    self.createUpload(self.path, h, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err2) {
+            if (!err2) {
+                t.fail('object size mismatch');
+                t.end();
+                return;
+            }
+
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'));
+            t.end();
+        });
+    });
+
+});
+
+
+test('commit upload: object size does not match create header (1 part)',
+function (t) {
+    var self = this;
+    var h = {
+        'content-length': helper.TEXT.length + 1
+    };
+    self.createUpload(self.path, h, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            var etag = res.headers.etag;
+            self.commitUpload(self.uploadId, [etag], function (err3) {
+                if (!err3) {
+                    t.fail('object size mismatch');
+                    t.end();
+                    return;
+                }
+
+                t.ok(verror.hasCauseWithName(err3,
+                    'MultipartUploadInvalidArgumentError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('commit upload: content-md5 does not match create header (0 parts)',
+function (t) {
+    var self = this;
+    var h = {
+        'content-md5': helper.TEXT_MD5
+    };
+
+    self.createUpload(self.path, h, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err2) {
+            if (!err2) {
+                t.fail('content MD5 mismatch');
+                t.end();
+                return;
+            }
+
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'));
+            t.end();
+        });
+    });
+
+});
+
+
+test('commit upload: content-md5 does not match create header (1 part)',
+function (t) {
+    var self = this;
+    var h = {
+        'content-md5': helper.ZERO_BYTE_MD5
+    };
+
+    self.createUpload(self.path, h, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            var etag = res.headers.etag;
+            self.commitUpload(self.uploadId, [etag], function (err3) {
+                if (!err3) {
+                    t.fail('content MD5 mismatch');
+                    t.end();
+                    return;
+                }
+
+                t.ok(verror.hasCauseWithName(err3,
+                    'MultipartUploadInvalidArgumentError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+
+test('commit upload: non-final part less than min part size', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var etags = [];
+        vasync.forEachParallel({
+            func: function uploadText(pn, cb) {
+                self.writeTestObject(self.uploadId, pn, function (errw, res) {
+                    if (!errw) {
+                        etags[pn] = res.headers.etag;
+                    }
+                    cb();
+                });
+            },
+            inputs: [0, 1, 2]
+        }, function (errp, results) {
+            if (ifErr(t, errp, 'uploading parts')) {
+                t.end();
+                return;
+            }
+
+            self.commitUpload(self.uploadId, etags, function (err2) {
+                if (!err2) {
+                    t.fail('non-final part has less than minimum size');
+                    t.end();
+                    return;
+                }
+
+                t.ok(verror.hasCauseWithName(err2,
+                    'MultipartUploadInvalidArgumentError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+// Commit: invalid object path specifed on create
+
+test('commit upload: path is top-level directory', function (t) {
+    var self = this;
+    var p = '/' + self.client.user + '/stor';
+
+    self.createUpload(p, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err2) {
+            if (!err2) {
+                t.fail('invalid object path (top-level directory)');
+                t.end();
+                return;
+            }
+
+            t.ok(verror.hasCauseWithName(err2,
+                'OperationNotAllowedOnDirectoryError'));
+             t.end();
+        });
+    });
+});
+
+
+test('commit upload: parent dir does not exist (parent is top-level dir)',
+function (t) {
+    var self = this;
+    var p = '/' + self.client.user + '/' + uuid.v4() + '/foo.txt';
+
+    self.createUpload(p, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err2) {
+            if (!err2) {
+                t.fail('invalid object path (parent is top-level directory)');
+                t.end();
+                return;
+            }
+
+            t.ok(verror.hasCauseWithName(err2, 'DirectoryDoesNotExistError'));
+             t.end();
+        });
+    });
+});
+
+
+test('commit upload: parent dir does not exist (parent is not a top-level dir)',
+function (t) {
+    var self = this;
+    var p = self.dir + '/foobar/foo.txt';
+
+    self.createUpload(p, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err2) {
+            if (!err2) {
+                t.fail('invalid object path (parent does not exist)');
+                t.end();
+                return;
+            }
+
+            t.ok(verror.hasCauseWithName(err2,
+                'DirectoryDoesNotExistError'));
+             t.end();
+        });
+    });
+});
+
+
+test('commit upload: object path under another account', function (t) {
+    var self = this;
+    var p = '/poseidon/stor/foo.txt';
+
+    self.createUpload(p, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.commitUpload(self.uploadId, [], function (err2) {
+            if (!err2) {
+                t.fail('upload created under a different account');
+                t.end();
+                return;
+            }
+
+            t.ok(verror.hasCauseWithName(err2,
+                'AuthorizationFailedError'));
+            t.end();
+        });
+    });
+});
+
+
+// Commit: bad inputs to API
+
+test('commit upload: empty part etag', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            self.commitUpload(self.uploadId, [''], function (err3) {
+                if (!err3) {
+                    t.fail('commit part 0 has an empty etag');
+                    t.end();
+                    return;
+                }
+
+                t.ok(verror.hasCauseWithName(err3,
+                    'MultipartUploadInvalidArgumentError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('commit upload: multiple empty part etags', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            var etag = res.headers.etag;
+
+            self.commitUpload(self.uploadId, ['', etag, ''], function (err3) {
+                if (!err3) {
+                    t.fail('commit parts 0 and 2 have empty etags');
+                    t.end();
+                    return;
+                }
+
+                t.ok(verror.hasCauseWithName(err3,
+                    'MultipartUploadInvalidArgumentError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('commit upload: incorrect part etag', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            self.commitUpload(self.uploadId, ['foobar'], function (err3) {
+                if (!err3) {
+                    t.fail('commit part 0 has incorrect etag');
+                    t.end();
+                    return;
+                }
+
+                t.ok(verror.hasCauseWithName(err3,
+                    'MultipartUploadInvalidArgumentError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('commit upload: more than 10000 parts specified', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+
+            var etag = res.headers.etag;
+            var parts = [];
+            for (var i = 0; i <= (helper.MAX_PART_NUM + 1); i++) {
+                parts[i] = etag;
+            }
+
+            self.commitUpload(self.uploadId, parts, function (err3) {
+                if (!err3) {
+                    t.fail('commit specified > 10000 parts');
+                    t.end();
+                    return;
+                }
+                t.ok(verror.hasCauseWithName(err3,
+                    'MultipartUploadInvalidArgumentError'));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('commit upload: non-uuid id', function (t) {
+    var self = this;
+    var bogus = 'foobar';
+    var action = 'commit';
+
+    var options = {
+        headers: {
+            'content-type': 'application/json',
+            'expect': 'application/json'
+        },
+        path: '/' + this.client.user + '/uploads/f/' + bogus + '/' + action
+    };
+
+    self.client.signRequest({
+        headers: options.headers
+    },
+    function (err) {
+        if (ifErr(t, err, 'sign request')) {
+            t.end();
+            return;
+        }
+
+        // We have to use the jsonClient directly or we will blow an assertion
+        // in node-manta, as the ID isn't a uuid.
+        self.client.jsonClient.post(options, {}, function (err2, _, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+
+            t.checkResponse(res, 404);
+            t.ok(verror.hasCauseWithName(err2, 'ResourceNotFoundError'));
+            t.end();
+        });
+    });
+});
+
+
+test('commit upload: non-existent id', function (t) {
+    var self = this;
+    var bogus = uuid.v4();
+    self.uploadId = bogus;
+    self.commitUpload(bogus, [], function (err, upload) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err, 'ResourceNotFoundError'));
+        t.end();
+    });
+});
+
+test('commit upload: error on undefined parts array', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        self.commitUpload(self.uploadId, undefined, function (err2) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'));
+            t.end();
+        });
+    });
+});

--- a/test/mpu/commit.test.js
+++ b/test/mpu/commit.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var MemoryStream = require('stream').PassThrough;

--- a/test/mpu/commit.test.js
+++ b/test/mpu/commit.test.js
@@ -29,6 +29,9 @@ var ifErr = helper.ifErr;
 var computePartsMD5 = helper.computePartsMD5;
 
 
+var mpuEnabled = Boolean(require('../../etc/config.json').enableMPU);
+if (mpuEnabled) {
+
 before(function (cb) {
     helper.initMPUTester.call(this, cb);
 });
@@ -840,3 +843,5 @@ test('commit upload: error on undefined parts array', function (t) {
         });
     });
 });
+
+} // mpuEnabled

--- a/test/mpu/create.test.js
+++ b/test/mpu/create.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var path = require('path');

--- a/test/mpu/create.test.js
+++ b/test/mpu/create.test.js
@@ -27,6 +27,9 @@ var ifErr = helper.ifErr;
 var computePartsMD5 = helper.computePartsMD5;
 
 
+var mpuEnabled = Boolean(require('../../etc/config.json').enableMPU);
+if (mpuEnabled) {
+
 before(function (cb) {
     helper.initMPUTester.call(this, cb);
 });
@@ -527,3 +530,5 @@ test('create upload: invalid content-disposition', function (t) {
         t.end();
     });
 });
+
+} // mpuEnabled

--- a/test/mpu/create.test.js
+++ b/test/mpu/create.test.js
@@ -1,0 +1,529 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+var path = require('path');
+var uuid = require('node-uuid');
+var verror = require('verror');
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+if (require.cache[__dirname + '/helper.js'])
+    delete require.cache[__dirname + '/helper.js'];
+var testHelper = require('../helper.js');
+var helper = require('./helper.js');
+
+var after = testHelper.after;
+var before = testHelper.before;
+var test = testHelper.test;
+
+var ifErr = helper.ifErr;
+var computePartsMD5 = helper.computePartsMD5;
+
+
+before(function (cb) {
+    helper.initMPUTester.call(this, cb);
+});
+
+
+after(function (cb) {
+    helper.cleanupMPUTester.call(this, cb);
+});
+
+
+// Create: happy cases
+test('create upload', function (t) {
+    var self = this;
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+            if (ifErr(t, err2, 'got upload')) {
+                t.end();
+                return;
+            }
+
+            t.deepEqual(upload.headers, h);
+            t.ok(upload.state, 'created');
+            t.end();
+        });
+    });
+});
+
+// Verifies that time-stamp set in the upload record
+// upon mpu creation exists and has a reasonable value.
+test('create upload: upload record creation time', function (t) {
+    var self = this;
+    var h = {};
+    var beforeUpload = Date.now();
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var afterUpload = Date.now();
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+            if (ifErr(t, err2, 'got upload')) {
+                t.end();
+                return;
+            }
+            t.ok(upload.creationTimeMs);
+            t.ok(beforeUpload < upload.creationTimeMs, 'before time check');
+            t.ok(upload.creationTimeMs < afterUpload, 'after time check');
+            t.end();
+        });
+    });
+});
+
+// content-length
+test('create upload: content-length header', function (t) {
+    var self = this;
+    var size = helper.randomUploadSize();
+    var h = {
+        'content-length': size
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+         if (ifErr(t, err, 'created upload')) {
+             t.end();
+             return;
+         }
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+             if (ifErr(t, err2, 'got upload')) {
+                 t.end();
+                 return;
+             }
+
+             t.deepEqual(upload.headers, h);
+             t.ok(upload.state, 'created');
+             t.end();
+        });
+    });
+});
+
+// durability-level
+test('create upload: durability-level header', function (t) {
+    var self = this;
+    var copies = helper.randomNumCopies();
+
+    var h = {
+        'durability-level': copies
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+            if (ifErr(t, err2, 'got upload')) {
+                t.end();
+                return;
+            }
+
+            t.deepEqual(upload.headers, h);
+            t.ok(upload.state, 'created');
+            t.end();
+        });
+    });
+});
+
+
+// x-durability-level
+test('create upload: x-durability-level header', function (t) {
+    var self = this;
+    var copies = helper.randomNumCopies();
+    var h = {
+        'x-durability-level': copies
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'got upload')) {
+            t.end();
+            return;
+        }
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+            if (ifErr(t, err2, 'got upload')) {
+                t.end();
+                return;
+            }
+
+            t.deepEqual(upload.headers, h);
+            t.ok(upload.state, 'created');
+            t.end();
+        });
+    });
+});
+
+
+// content-md5
+test('create upload: content-md5 header', function (t) {
+    var self = this;
+    var h = {
+        'content-md5': 'JdMoQCNCYOHEGq1fgaYyng=='
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+            t.ifError(err2);
+            if (ifErr(t, err, 'created upload')) {
+                t.end();
+                return;
+            }
+
+            t.deepEqual(upload.headers, h);
+            t.ok(upload.state, 'created');
+            t.end();
+        });
+    });
+});
+
+
+// mix of headers, supported and unsupported
+test('create upload: various headers', function (t) {
+    var self = this;
+    var copies = helper.randomNumCopies();
+    var size = helper.randomUploadSize();
+
+    var h = {
+        'content-length': size,
+        'durability-level': copies,
+        'content-md5': 'JdMoQCNCYOHEGq1fgaYyng==',
+        'm-my-custom-header': 'my-custom-value'
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+            if (ifErr(t, err2, 'got upload')) {
+                t.end();
+                return;
+            }
+
+            t.deepEqual(upload.headers, h);
+            t.ok(upload.state, 'created');
+            t.end();
+        });
+    });
+});
+
+
+// make sure headers are case-insensitive
+test('create upload: mixed case headers', function (t) {
+    var self = this;
+    var copies = helper.randomNumCopies();
+    var size = helper.randomUploadSize();
+    var h = {
+        'Content-Length': size,
+        'DURABILITY-LEVEL': copies,
+        'cOntEnt-Md5': 'JdMoQCNCYOHEGq1fgaYyng==',
+        'm-my-CuStoM-header': 'my-custom-value'
+    };
+
+    // only headers should be case-insensitive (values shouldn't change)
+    var lowerCase = {
+        'content-length': size,
+        'durability-level': copies,
+        'content-md5': 'JdMoQCNCYOHEGq1fgaYyng==',
+        'm-my-custom-header': 'my-custom-value'
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+            if (ifErr(t, err2, 'got upload')) {
+                t.end();
+                return;
+            }
+
+            t.deepEqual(upload.headers, lowerCase);
+            t.ok(upload.state, 'created');
+            t.end();
+        });
+    });
+});
+
+
+// Create: bad input
+
+test('create upload: no input object path', function (t) {
+    var self = this;
+
+    self.createUpload(null, null, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'MultipartUploadInvalidArgumentError'), err);
+        t.end();
+    });
+});
+
+test('create upload: object path under a nonexistent account', function (t) {
+    var self = this;
+    var bogus = uuid.v4();
+    var p = '/' + bogus + '/foo.txt';
+
+    self.createUpload(p, null, function (err) {
+        if (!err) {
+            t.fail('upload created under a different account');
+            t.end();
+            return;
+        }
+
+        t.ok(verror.hasCauseWithName(err, 'AccountDoesNotExistError'));
+        t.end();
+    });
+});
+
+
+test('create upload: object path not a string', function (t) {
+    var self = this;
+
+    self.createUpload([], null, function (err, o) {
+        t.ok(err); //TODO error message name
+        if (!err) {
+            return (t.end());
+        }
+        t.end();
+    });
+});
+
+
+test('create upload: if-match header disalowed', function (t) {
+    var self = this;
+    var h = {
+        'if-match': 'foo'
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'MultipartUploadInvalidArgumentError'), err);
+        t.end();
+    });
+});
+
+
+test('create upload: if-none-match header disalowed', function (t) {
+    var self = this;
+    var h = {
+        'if-none-match': 'foo'
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'MultipartUploadInvalidArgumentError'), err);
+        t.end();
+    });
+});
+
+
+test('create upload: if-modified-since header disalowed', function (t) {
+    var self = this;
+    var h = {
+        'if-modified-since': 'foo'
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'MultipartUploadInvalidArgumentError'), err);
+        t.end();
+    });
+});
+
+test('create upload: if-unmodified-since header disalowed', function (t) {
+    var self = this;
+    var h = {
+        'if-unmodified-since': 'foo'
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'MultipartUploadInvalidArgumentError'), err);
+        t.end();
+    });
+});
+
+
+test('create upload: content-length less than allowed', function (t) {
+    var self = this;
+    var size = helper.MIN_UPLOAD_SIZE - 1;
+    var h = {
+        'content-length': size
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'MultipartUploadInvalidArgumentError'), err);
+        t.end();
+    });
+});
+
+
+test('create upload: durability-level greater than allowed', function (t) {
+    var self = this;
+    var copies = helper.MAX_NUM_COPIES + 1;
+    var h = {
+        'durability-level': copies
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'InvalidDurabilityLevelError'), err);
+        t.end();
+    });
+});
+
+test('create upload: x-durability-level greater than allowed', function (t) {
+    var self = this;
+    var copies = helper.MAX_NUM_COPIES + 1;
+    var h = {
+        'x-durability-level': copies
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'InvalidDurabilityLevelError'), err);
+        t.end();
+    });
+});
+
+
+test('create upload: durability-level less than allowed', function (t) {
+    var self = this;
+    var copies = helper.MIN_NUM_COPIES - 1;
+    var h = {
+        'durability-level': copies
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'InvalidDurabilityLevelError'), err);
+        t.end();
+    });
+});
+
+
+test('create upload: x-durability-level less than allowed', function (t) {
+    var self = this;
+    var copies = helper.MIN_NUM_COPIES - 1;
+    var h = {
+        'x-durability-level': copies
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'InvalidDurabilityLevelError'), err);
+        t.end();
+    });
+});
+
+// content-disposition
+test('create upload: content-disposition header', function (t) {
+    var self = this;
+    var cd = 'attachment; filename="my-file.txt"';
+    var h = {
+        'content-disposition': cd
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.getUpload(self.uploadId, function (err2, upload) {
+            if (ifErr(t, err2, 'got upload')) {
+                t.end();
+                return;
+            }
+
+            t.deepEqual(upload.headers, h, 'created headers match');
+            t.ok(upload.state, 'created');
+            t.end();
+        });
+    });
+});
+
+
+test('create upload: invalid content-disposition', function (t) {
+    var self = this;
+    var h = {
+        'content-disposition': 'attachment;'
+    };
+
+    self.createUpload(self.path, h, function (err, o) {
+        t.ok(err, 'Expect error');
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err,
+            'BadRequestError'), 'Expected 400');
+        t.end();
+    });
+});

--- a/test/mpu/del.test.js
+++ b/test/mpu/del.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var path = require('path');

--- a/test/mpu/del.test.js
+++ b/test/mpu/del.test.js
@@ -27,6 +27,9 @@ var test = testHelper.test;
 var ifErr = helper.ifErr;
 
 
+var mpuEnabled = Boolean(require('../../etc/config.json').enableMPU);
+if (mpuEnabled) {
+
 before(function (cb) {
     helper.initMPUTester.call(this, cb);
 });
@@ -375,3 +378,5 @@ test('del part: operator but query param is not bool', function (t) {
         });
     });
 });
+
+} // mpuEnabled

--- a/test/mpu/del.test.js
+++ b/test/mpu/del.test.js
@@ -1,0 +1,377 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2017, Joyent, Inc.
+ */
+
+var path = require('path');
+var uuid = require('node-uuid');
+var vasync = require('vasync');
+var verror = require('verror');
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+if (require.cache[__dirname + '/helper.js'])
+    delete require.cache[__dirname + '/helper.js'];
+var testHelper = require('../helper.js');
+var helper = require('./helper.js');
+
+var after = testHelper.after;
+var before = testHelper.before;
+var test = testHelper.test;
+
+var ifErr = helper.ifErr;
+
+
+before(function (cb) {
+    helper.initMPUTester.call(this, cb);
+});
+
+
+after(function (cb) {
+    helper.cleanupMPUTester.call(this, cb);
+});
+
+
+// Delete parts/upload directories: allowed cases
+
+test('del upload directory with operator override', function (t) {
+    var self = this;
+
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            query: {
+                allowMpuDeletes: true
+            }
+        };
+        self.operatorClient.unlink(self.uploadPath(), opts,
+        function (err2, res) {
+            if (ifErr(t, err2, 'unlink')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+            t.end();
+        });
+    });
+});
+
+
+test('del part with operator override', function (t) {
+    var self = this;
+
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MIN_PART_NUM;
+        self.writeTestObject(self.uploadId, pn, function (err2, _) {
+            if (ifErr(t, err, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            var opts = {
+                query: {
+                    allowMpuDeletes: true
+                }
+            };
+            self.operatorClient.unlink(self.uploadPath(pn), opts,
+            function (err3, res) {
+                if (ifErr(t, err3, 'unlink')) {
+                    t.end();
+                    return;
+                }
+
+                t.ok(res);
+                t.checkResponse(res, 204);
+                t.end();
+            });
+        });
+    });
+});
+
+
+// Delete parts/upload directories: operator, no override provided
+
+test('del upload directory: operator but no override', function (t) {
+    var self = this;
+
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        self.operatorClient.unlink(self.uploadPath(), function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2,
+                'UnprocessableEntityError'), err2);
+            t.checkResponse(res, 422);
+            t.end();
+        });
+    });
+});
+
+
+test('del part: operator but no override', function (t) {
+    var self = this;
+
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MIN_PART_NUM;
+        self.writeTestObject(self.uploadId, pn, function (err2, _) {
+            if (ifErr(t, err, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            self.operatorClient.unlink(self.uploadPath(pn),
+            function (err3, res) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+                }
+                t.ok(verror.hasCauseWithName(err3,
+                    'UnprocessableEntityError'), err3);
+                t.checkResponse(res, 422);
+                t.end();
+            });
+        });
+    });
+});
+
+
+// Delete parts/upload directories: non-operator, override provided
+
+test('del upload directory: non-operator with override', function (t) {
+    var self = this;
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            query: {
+                allowMpuDeletes: true
+            }
+        };
+
+        self.client.unlink(self.uploadPath(), opts, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2,
+                'MethodNotAllowedError'), err2);
+            t.checkResponse(res, 405);
+            t.end();
+        });
+    });
+});
+
+
+test('del part: non-operator with override', function (t) {
+    var self = this;
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MIN_PART_NUM;
+        self.writeTestObject(self.uploadId, pn, function (err2, _) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            var opts = {
+                query: {
+                    allowMpuDeletes: true
+                }
+            };
+
+            self.client.unlink(self.uploadPath(pn), opts, function (err3, res) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+                }
+                t.ok(verror.hasCauseWithName(err3,
+                    'MethodNotAllowedError'), err3);
+                t.checkResponse(res, 405);
+                t.end();
+            });
+        });
+    });
+});
+
+
+// Delete parts/upload directories: operator, but query param is not `true`
+
+test('del upload directory: operator but query param is false', function (t) {
+    var self = this;
+
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            query: {
+                allowMpuDeletes: false
+            }
+        };
+
+        self.operatorClient.unlink(self.uploadPath(), opts,
+        function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2,
+                'UnprocessableEntityError'), err2);
+            t.checkResponse(res, 422);
+            t.end();
+        });
+    });
+});
+
+
+test('del part: operator but query param is false', function (t) {
+    var self = this;
+
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MIN_PART_NUM;
+        self.writeTestObject(self.uploadId, pn, function (err2, _) {
+            if (ifErr(t, err, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            var opts = {
+                query: {
+                    allowMpuDeletes: false
+                }
+            };
+
+            self.operatorClient.unlink(self.uploadPath(pn), opts,
+            function (err3, res) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+                }
+                t.ok(verror.hasCauseWithName(err3,
+                    'UnprocessableEntityError'), err3);
+                t.checkResponse(res, 422);
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('del upload directory: operator but query param is not bool',
+function (t) {
+    var self = this;
+
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            query: {
+                allowMpuDeletes: 1
+            }
+        };
+
+        self.operatorClient.unlink(self.uploadPath(), opts,
+        function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.ok(verror.hasCauseWithName(err2,
+                'UnprocessableEntityError'), err2);
+            t.checkResponse(res, 422);
+            t.end();
+        });
+    });
+});
+
+
+test('del part: operator but query param is not bool', function (t) {
+    var self = this;
+
+    var h = {};
+    self.createUpload(self.path, h, function (err, o) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MIN_PART_NUM;
+        self.writeTestObject(self.uploadId, pn, function (err2, _) {
+            if (ifErr(t, err, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            var opts = {
+                query: {
+                    allowMpuDeletes: false
+                }
+            };
+
+            self.operatorClient.unlink(self.uploadPath(pn), opts,
+            function (err3, res) {
+                t.ok(err3);
+                if (!err3) {
+                    return (t.end());
+                }
+                t.ok(verror.hasCauseWithName(err3,
+                    'UnprocessableEntityError'), err3);
+                t.checkResponse(res, 422);
+                t.end();
+            });
+        });
+    });
+});

--- a/test/mpu/get.test.js
+++ b/test/mpu/get.test.js
@@ -1,0 +1,89 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2017, Joyent, Inc.
+ */
+
+var path = require('path');
+var uuid = require('node-uuid');
+var vasync = require('vasync');
+var verror = require('verror');
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+if (require.cache[__dirname + '/helper.js'])
+    delete require.cache[__dirname + '/helper.js'];
+var testHelper = require('../helper.js');
+var helper = require('./helper.js');
+
+var after = testHelper.after;
+var before = testHelper.before;
+var test = testHelper.test;
+
+var ifErr = helper.ifErr;
+
+before(function (cb) {
+    helper.initMPUTester.call(this, cb);
+});
+
+
+after(function (cb) {
+    helper.cleanupMPUTester.call(this, cb);
+});
+
+
+// Get: bad input (happy path tested in create)
+
+test('get upload: non-uuid id', function (t) {
+    var self = this;
+    var bogus = 'foobar';
+    var action = 'state';
+    var p = '/' + this.client.user + '/uploads/0/' + bogus + '/' + action;
+    var options = {
+        headers: {
+            'content-type': 'application/json',
+            'expect': 'application/json'
+        }
+    };
+
+    self.client.signRequest({
+        headers: options.headers
+    },
+    function (err) {
+        if (ifErr(t, err, 'sign request')) {
+            t.end();
+            return;
+        }
+
+        self.client.get(p, options, function (err2, _, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+
+            t.checkResponse(res, 404);
+            t.ok(verror.hasCauseWithName(err2, 'ResourceNotFoundError'));
+            t.end();
+        });
+    });
+});
+
+
+test('get upload: non-existent id', function (t) {
+    var self = this;
+    var bogus = uuid.v4();
+    self.uploadId = bogus;
+
+    self.getUpload(bogus, function (err, upload) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err, 'ResourceNotFoundError'), err);
+        t.end();
+    });
+});

--- a/test/mpu/get.test.js
+++ b/test/mpu/get.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var path = require('path');

--- a/test/mpu/get.test.js
+++ b/test/mpu/get.test.js
@@ -26,6 +26,9 @@ var test = testHelper.test;
 
 var ifErr = helper.ifErr;
 
+var mpuEnabled = Boolean(require('../../etc/config.json').enableMPU);
+if (mpuEnabled) {
+
 before(function (cb) {
     helper.initMPUTester.call(this, cb);
 });
@@ -87,3 +90,5 @@ test('get upload: non-existent id', function (t) {
         t.end();
     });
 });
+
+} // mpuEnabled

--- a/test/mpu/helper.js
+++ b/test/mpu/helper.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var assert = require('assert-plus');

--- a/test/mpu/helper.js
+++ b/test/mpu/helper.js
@@ -1,0 +1,580 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2018, Joyent, Inc.
+ */
+
+var assert = require('assert-plus');
+var crypto = require('crypto');
+var jsprim = require('jsprim');
+var fs = require('fs');
+var manta = require('manta');
+var MemoryStream = require('stream').PassThrough;
+var obj = require('../../lib/obj');
+var path = require('path');
+var sshpk = require('sshpk');
+var util = require('util');
+var uuid = require('node-uuid');
+
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+var testHelper = require('../helper.js');
+
+
+///--- Globals
+
+var sprintf = util.format;
+
+var MIN_UPLOAD_SIZE = 0;
+var MAX_TEST_UPLOAD_SIZE = 1000;
+
+var MIN_NUM_COPIES = obj.DEF_MIN_COPIES;
+var MAX_NUM_COPIES = obj.DEF_MAX_COPIES;
+
+var MIN_PART_NUM = 0;
+var MAX_PART_NUM = 9999;
+
+var ZERO_BYTE_MD5 = obj.ZERO_BYTE_MD5;
+
+var TEXT = 'The lazy brown fox \nsomething \nsomething foo';
+var TEXT_MD5 = crypto.createHash('md5').update(TEXT).digest('base64');
+
+///--- Helpers
+
+/*
+ * All MPU-related tests should use this in the test setup code, and the
+ * complimentary cleanupMPUTester function in the test teardown code.
+ *
+ * This function sets up some helper methods on the tester object that provide
+ * are cleaned up properly.  Specifically, when an upload is created, the
+ * `uploadId` field is set to the MPU's upload ID. If it is finalized using
+ * the helper methods {abort,commit}Upload, the `uploadFinalized` flag is set.
+ * On teardown, we use these flags to ensure all uploads are finalized so that
+ * they will be garbage collected.
+ */
+function initMPUTester(tcb) {
+    var self = this;
+
+    self.client = testHelper.createClient();
+    self.userClient = testHelper.createUserClient('muskie_test_user');
+    self.operatorClient = testHelper.createOperatorClient();
+
+    self.uploadsRoot = '/' + self.client.user + '/uploads';
+    self.root = '/' + self.client.user + '/stor';
+    self.dir = self.root + '/' + uuid.v4();
+    self.path = self.dir + '/' + uuid.v4();
+
+    self.uploadId = null;
+    self.partsDirectory = null;
+    self.uploadFinalized = false;
+
+    self.mskPrefixLength = null;
+
+    // Thin wrappers around the MPU API.
+    self.createUpload = function create(p, headers, cb) {
+        createUploadHelper.call(self, p, headers, self.client, cb);
+    };
+    self.abortUpload = function abort(id, cb) {
+        abortUploadHelper.call(self, id, self.client, cb);
+    };
+    self.commitUpload = function commit(id, etags, cb) {
+        commitUploadHelper.call(self, id, etags, self.client, cb);
+    };
+    self.getUpload = function get(id, cb) {
+        getUploadHelper.call(self, id, self.client, cb);
+    };
+    self.writeTestObject = function writeObject(id, partNum, cb) {
+        writeObjectHelper.call(self, id, partNum, TEXT, self.client, cb);
+    };
+
+    // Wrappers using subusers as the caller.
+    self.createUploadSubuser = function createSubuser(p, headers, cb) {
+        createUploadHelper.call(self, p, headers, self.userClient, cb);
+    };
+    self.abortUploadSubuser = function abortSubuser(id, cb) {
+        abortUploadHelper.call(self, id, self.userClient, cb);
+    };
+    self.commitUploadSubuser = function commitSubuser(id, etags, cb) {
+        commitUploadHelper.call(self, id, etags, self.userClient, cb);
+    };
+    self.getUploadSubuser = function getSubuser(id, cb) {
+        getUploadHelper.call(self, id, self.userClient, cb);
+    };
+    self.writeTestObjectSubuser = function writeObjectSubuser(id, partNum, cb) {
+        writeObjectHelper.call(self, id, partNum, TEXT, self.userClient, cb);
+    };
+
+   /*
+    * Returns the path a client can use to get redirected to the real
+    * partsDirectory of a created MPU.
+    *
+    * Inputs:
+    * - pn: optional part num to include in the path
+    */
+    self.redirectPath = function redirectPath(pn) {
+        assert.ok(self.uploadId);
+        var p = self.uploadsRoot + '/' + self.uploadId;
+        if (typeof (pn) === 'number') {
+            p += '/' + pn;
+        }
+        return (p);
+    };
+
+   /*
+    * Returns the partsDirectory of a created MPU.
+    *
+    * Inputs:
+    * - pn: optional part num to include in the path
+    */
+    self.uploadPath = function uploadPath(pn) {
+        var p;
+        if (self.partsDirectory) {
+            p = self.partsDirectory;
+        } else {
+            assert.ok(self.uploadId, 'self.uploadId');
+            var c = self.uploadId.charAt(self.uploadId.length - 1);
+            var len = jsprim.parseInteger(c, { base: 16 });
+            if ((typeof (len) !== 'number') || (len < 1) || (len > 4)) {
+                len = 1;
+            }
+
+            var prefix = self.uploadId.substring(0, len);
+            p = '/' + self.client.user + '/uploads/' + prefix + '/' +
+                self.uploadId;
+        }
+
+        if (typeof (pn) === 'number') {
+            p += '/' + pn;
+        }
+        return (p);
+    };
+
+    self.client.mkdir(self.dir, function (mkdir_err) {
+        if (mkdir_err) {
+            tcb(mkdir_err);
+        } else {
+            tcb(null);
+        }
+    });
+}
+
+/*
+ * All MPU-related tests should use this in the test teardown code, and the
+ * complimentary initMPUTester function in the test setup code.
+ *
+ * This function ensures that if an upload was created and not finalized by the
+ * test, it is aborted, so that the MPU can be garbage collected. It also
+ * closes open clients and removes test objects created as a part of the test.
+ */
+function cleanupMPUTester(cb) {
+    var self = this;
+    function closeClients(ccb) {
+        this.client.close();
+        this.userClient.close();
+        ccb();
+    }
+
+    self.client.rmr(self.dir, function () {
+        if (self.uploadId && !self.uploadFinalized) {
+            var opts = {
+                account: self.client.user,
+                partsDirectory: self.uploadPath()
+            };
+            self.client.abortUpload(self.uploadId, opts,
+                closeClients.bind(self, cb));
+        } else {
+            closeClients.call(self, cb);
+        }
+    });
+}
+
+
+/*
+ * Helper that creates an upload and passes the object returned from `create`
+ * to the callback. On success, it will do a basic sanity check on the object
+ * returned by create using the tester.
+ *
+ * Parameters:
+ *  - p: the target object path to pass to `create`
+ *  - h: a headers object to pass to `create`
+ *  - client: client to use for the request
+ *  - cb: callback of the form cb(err, object)
+ */
+function createUploadHelper(p, h, client, cb) {
+    var self = this;
+    assert.object(self);
+    assert.object(client);
+    assert.func(cb);
+
+    var opts = {
+        headers: {
+            'content-type': 'application/json',
+            'expect': 'application/json'
+        },
+        path: self.uploadsRoot
+    };
+
+    client.signRequest({
+        headers: opts.headers
+    }, function (err) {
+        if (err) {
+            cb(err);
+        } else {
+            var body = {};
+            if (p) {
+                body.objectPath = p;
+            }
+            if (h) {
+                body.headers = h;
+            }
+
+            self.client.jsonClient.post(opts, body,
+            function (err2, req, res, o) {
+                if (err2) {
+                    cb(err2);
+                } else {
+                    self.uploadId = o.id;
+                    self.partsDirectory = o.partsDirectory;
+                    var err3 = checkCreateResponse(o);
+                    if (err3) {
+                        cb(err2);
+                    } else {
+                        cb(null, o);
+                    }
+                }
+            });
+        }
+    });
+}
+
+/*
+ * Helper that gets a created upload and passes the object returned
+ * to the callback. On success, it will do a basic sanity check on the object
+ * returned.
+ *
+ * Parameters:
+ *  - id: the upload ID to `get`
+ *  - client: client to use for the request
+ *  - cb: callback of the form cb(err, upload)
+ */
+function getUploadHelper(id, client, cb) {
+    var self = this;
+    assert.object(self);
+    assert.string(id);
+    assert.object(client);
+    assert.func(cb);
+
+    var opts = {
+        account: self.client.user,
+        partsDirectory: self.uploadPath()
+    };
+
+    client.getUpload(id, opts, function (err, upload) {
+        if (err) {
+            cb(err);
+        } else {
+            var err2 = checkGetResponse.call(self, upload);
+            if (err2) {
+                cb(err2);
+            } else {
+                cb(null, upload);
+            }
+        }
+    });
+}
+
+/*
+ * Helper that aborts an MPU and sets the `uploadFinalized` flag on the tester
+ * object.
+ *
+ * Parameters:
+ *  - id: the upload ID
+ *  - client: client to use for the request
+ *  - cb: callback of the form cb(err)
+ */
+function abortUploadHelper(id, client, cb) {
+    var self = this;
+    assert.object(self);
+    assert.string(id);
+    assert.object(client);
+    assert.func(cb);
+
+    var opts = {
+        account: self.client.user,
+        partsDirectory: self.uploadPath()
+    };
+
+    client.abortUpload(id, opts, function (err) {
+        if (err) {
+            cb(err);
+        } else {
+            self.uploadFinalized = true;
+            cb();
+        }
+    });
+}
+
+
+/*
+ * Helper that commits an MPU and sets the `uploadFinalized` flag on the tester
+ * object.
+ *
+ * Parameters:
+ *  - id: the upload ID
+ *  - etags: an array of etags representing parts to commit
+ *  - client: client to use for the request
+ *  - cb: callback of the form cb(err)
+ */
+function commitUploadHelper(id, etags, client, cb) {
+    var self = this;
+    assert.object(self);
+    assert.string(id);
+    assert.object(client);
+    assert.func(cb);
+
+    var opts = {
+        account: self.client.user,
+        partsDirectory: self.uploadPath()
+    };
+
+    client.commitUpload(id, etags, opts, function (err, res) {
+        if (err) {
+            cb(err);
+        } else {
+            self.uploadFinalized = true;
+            cb(null, res);
+        }
+    });
+}
+
+
+/*
+ * Uploads a test object to an upload.
+ *
+ * Parameters:
+ *  - id: the upload ID
+ *  - partNum: the part number
+ *  - string: string representing the object data
+ *  - client: client to use for the request
+ *  - cb: callback of the form cb(err, res)
+ */
+function writeObjectHelper(id, partNum, string, client, cb) {
+    var self = this;
+    assert.object(self);
+    assert.string(string);
+    assert.object(client);
+    assert.func(cb);
+
+    var opts = {
+        account: self.client.user,
+        md5: crypto.createHash('md5').update(string).digest('base64'),
+        size: Buffer.byteLength(string),
+        type: 'text/plain',
+        partsDirectory: self.uploadPath()
+    };
+
+    var stream = new MemoryStream();
+    client.put(self.uploadPath(partNum), stream, opts, cb);
+    setImmediate(stream.end.bind(stream, string));
+}
+
+
+function ifErr(t, err, desc) {
+    t.ifError(err, desc);
+    if (err) {
+        t.deepEqual(err.body, {}, desc + ': error body');
+        return (true);
+    }
+
+    return (false);
+}
+
+function between(min, max) {
+    return (Math.floor(Math.random() * (max - min + 1) + min));
+}
+
+function randomPartNum() {
+    return (between(MIN_PART_NUM, MAX_PART_NUM));
+}
+
+function randomUploadSize() {
+    return (between(MIN_UPLOAD_SIZE, MAX_TEST_UPLOAD_SIZE));
+}
+
+function randomNumCopies() {
+    return (between(MIN_NUM_COPIES, 3));
+}
+
+
+// Given an array of etags, returns the md5 we expect from the MPU API.
+function computePartsMD5(parts) {
+    var hash = crypto.createHash('md5');
+    parts.forEach(function (p) {
+        hash.update(p);
+    });
+
+    return (hash.digest('base64'));
+}
+
+
+/*
+ * Verifies that the response sent by muskie on create-mpu is correct. If it's
+ * not, we return an error.
+ *
+ * Inputs:
+ *  - o: the object returned from create-mpu
+ */
+function checkCreateResponse(o) {
+    if (!o) {
+        return (new Error('create-mpu returned no response'));
+    }
+
+    if (!o.id) {
+        return (new Error('create-mpu did not return an upload ID'));
+    }
+
+    if (!o.partsDirectory) {
+        return (new Error('create-mpu did not return a parts directory'));
+    }
+
+    if (!(o.id === path.basename(o.partsDirectory))) {
+        return (new Error('create-mpu returned an upload ID that does not ' +
+            'match its parts directory'));
+    }
+
+    return (null);
+}
+
+/*
+ * Verifies that the response sent by muskie on get-mpu is correct. If anything
+ * is wrong, we return an error.
+ *
+ * Inputs:
+ *  - u: the object returned from get-mpu
+ */
+function checkGetResponse(u) {
+    if (!u) {
+        return (new Error('get-mpu returned no response'));
+    }
+
+    if (!u.id) {
+        return (new Error('get-mpu did not return an upload ID'));
+    }
+
+    // Verify that the id from create-mpu matches what get-mpu said.
+    if (this.uploadId) {
+        if (this.uploadId !== u.id) {
+            return (new Error(sprintf('get-mpu returned an upload with a ' +
+                'different id than was returned from create-mpu: ' +
+                'expected id "%s", but got id "%s"',
+                this.uploadId, u.id)));
+        }
+
+        if (u.state === 'created') {
+            if (this.partsDirectory !== u.partsDirectory) {
+                return (new Error(sprintf('get-mpu returned an upload with a ' +
+                    'different partsDirectory than was returned from ' +
+                    'create-mpu: expected partsDirectory "%s", but got "%s"',
+                    this.partsDirectory, u.partsDirectory)));
+            }
+        }
+    }
+
+    if (!u.state) {
+        return (new Error('get-mpu did not return an upload state'));
+    }
+
+    if (!(u.state === 'created' || u.state === 'finalizing' ||
+       u.state === 'done')) {
+        return (new Error(sprintf('get-mpu returned an invalid state: %s',
+            u.state)));
+    }
+
+    if (!u.targetObject) {
+        return (new Error('get-mpu did not return the target object path'));
+    }
+
+    if (!u.headers) {
+        return (new Error('get-mpu did not return the target object headers'));
+    }
+
+    if (!u.numCopies) {
+        return (new Error('get-mpu did not return numCopies for the target ' +
+            'object'));
+    }
+
+    if (!u.headers) {
+        return (new Error('get-mpu did not return the target object headers'));
+    }
+
+    if (!u.creationTimeMs) {
+        return (new Error('get-mpu did not return the mpu creation time'));
+    }
+
+    if (u.state === 'created') {
+        // A created upload will have 'partsDirectory', but finalized uploads
+        // will not.
+        if (!u.partsDirectory) {
+            return (new Error('get-mpu returned an upload in state "created" ' +
+                'with no "partsDirectory" field'));
+        }
+    } else if (u.state === 'finalizing') {
+        if (!u.type) {
+            return (new Error('get-mpu returned an upload in state ' +
+                '"finalizing" with no "type" field'));
+        }
+        if (!(u.type === 'abort' || u.type === 'commit')) {
+            return (new Error(sprintf('get-mpu returned an upload in state ' +
+                '"finalizing" with invalid "type": %s'), u.type));
+        }
+
+    } else {
+        // Uploads in state "done" have a "result" field that specifies whether
+        // it was committed or aborted, but no type.
+        if (!u.result) {
+            return (new Error('get-mpu returned an upload in state ' +
+                '"done" with no "result" field'));
+        }
+        if (!(u.result === 'aborted' || u.result === 'committed')) {
+            return (new Error(sprintf('get-mpu returned an upload in state ' +
+                '"finalizing" with invalid "result": %s', u.result)));
+        }
+        if (u.result === 'committed') {
+            if (!u.partsMD5Summary) {
+                return (new Error('get-mpu returned an upload in state ' +
+                    '"finalizing", result "committed", with no ' +
+                    '"partsMD5Summary" field'));
+            }
+        }
+    }
+
+    return (null);
+}
+
+///--- Exports
+
+module.exports = {
+    MIN_UPLOAD_SIZE: MIN_UPLOAD_SIZE,
+    MAX_TEST_UPLOAD_SIZE: MAX_TEST_UPLOAD_SIZE,
+    MIN_NUM_COPIES: MIN_NUM_COPIES,
+    MAX_NUM_COPIES: MAX_NUM_COPIES,
+    MIN_PART_NUM: MIN_PART_NUM,
+    MAX_PART_NUM: MAX_PART_NUM,
+    TEXT: TEXT,
+    TEXT_MD5: TEXT_MD5,
+    ZERO_BYTE_MD5: ZERO_BYTE_MD5,
+
+    cleanupMPUTester: cleanupMPUTester,
+    initMPUTester: initMPUTester,
+    ifErr: ifErr,
+    between: between,
+    randomPartNum: randomPartNum,
+    randomUploadSize: randomUploadSize,
+    randomNumCopies: randomNumCopies,
+    computePartsMD5: computePartsMD5
+};

--- a/test/mpu/redirect.test.js
+++ b/test/mpu/redirect.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var manta = require('manta');

--- a/test/mpu/redirect.test.js
+++ b/test/mpu/redirect.test.js
@@ -1,0 +1,355 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2017, Joyent, Inc.
+ */
+
+var manta = require('manta');
+var path = require('path');
+var MemoryStream = require('stream').PassThrough;
+var uuid = require('node-uuid');
+var vasync = require('vasync');
+var verror = require('verror');
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+if (require.cache[__dirname + '/helper.js'])
+    delete require.cache[__dirname + '/helper.js'];
+var testHelper = require('../helper.js');
+var helper = require('./helper.js');
+
+var after = testHelper.after;
+var before = testHelper.before;
+var test = testHelper.test;
+
+var ifErr = helper.ifErr;
+
+
+before(function (cb) {
+    helper.initMPUTester.call(this, cb);
+});
+
+
+after(function (cb) {
+    helper.cleanupMPUTester.call(this, cb);
+});
+
+
+// Redirect
+
+test('redirect upload: GET /:account/uploads/:id', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+        self.client.get(self.redirectPath(), opts,
+        function (err2, stream, res) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            t.checkResponse(res, 301);
+            t.equal(res.headers.location, self.uploadPath());
+            t.end();
+        });
+    });
+});
+
+
+test('redirect upload: PUT /:account/uploads/:id', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+
+        var s = new MemoryStream();
+        self.client.put(self.redirectPath(), s, opts, function (err2, res) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            t.checkResponse(res, 301);
+            t.equal(res.headers.location, self.uploadPath());
+            t.end();
+        });
+    });
+});
+
+
+test('redirect upload: HEAD /:account/uploads/:id', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+        self.client.info(self.redirectPath(), opts, function (err2, res) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            // info() doesn't return a status code, but if the location is in
+            // location header, the redirect was successful.
+            t.equal(res.headers.location, self.uploadPath());
+            t.end();
+        });
+    });
+});
+
+
+test('redirect upload: POST /:account/uploads/:id', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var options = {
+            headers: {
+                'content-type': 'application/json',
+                'expect': 'application/json'
+            },
+            path: self.redirectPath()
+        };
+
+        self.client.signRequest({
+            headers: options.headers
+        },
+        function (err2) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            self.client.jsonClient.post(options, {}, function (err3, _, res) {
+                if (ifErr(t, err3, 'redirect upload')) {
+                    t.end();
+                    return;
+                }
+
+                t.checkResponse(res, 301);
+                t.equal(res.headers.location, self.uploadPath());
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('redirect upload: DELETE /:account/uploads/:id', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+        self.client.unlink(self.redirectPath(), opts, function (err2, res) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            t.checkResponse(res, 301);
+            t.equal(res.headers.location, self.uploadPath());
+            t.end();
+        });
+    });
+});
+
+
+test('redirect upload: GET /:account/uploads/:id/:partNum', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+
+        var pn = 0;
+        self.client.get(self.redirectPath(pn), opts,
+        function (err2, stream, res) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            t.checkResponse(res, 301);
+            t.equal(res.headers.location, self.uploadPath(pn));
+            t.end();
+        });
+    });
+});
+
+
+test('redirect upload: PUT /:account/uploads/:id/:partNum', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+        var s = new MemoryStream();
+        var pn = 0;
+        self.client.put(self.redirectPath(pn), s, opts, function (err2, res) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            t.checkResponse(res, 301);
+            t.equal(res.headers.location, self.uploadPath(pn));
+            t.end();
+        });
+    });
+});
+
+
+test('redirect upload: HEAD /:account/uploads/:id/:partNum', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+        var pn = 0;
+        self.client.info(self.redirectPath(pn), opts, function (err2, res) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            // info() doesn't return a status code, but if the location is in
+            // location header, the redirect was successful.
+            t.equal(res.headers.location, self.uploadPath(pn));
+            t.end();
+        });
+    });
+});
+
+
+test('redirect upload: POST /:account/uploads/:id/:partNum', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = 0;
+        var options = {
+            headers: {
+                'content-type': 'application/json',
+                'expect': 'application/json'
+            },
+            path: self.redirectPath(pn)
+        };
+
+        self.client.signRequest({
+            headers: options.headers
+        },
+        function (err2) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            self.client.jsonClient.post(options, {}, function (err3, _, res) {
+                if (ifErr(t, err3, 'redirect upload')) {
+                    t.end();
+                    return;
+                }
+
+                t.checkResponse(res, 301);
+                t.equal(res.headers.location, self.uploadPath(pn));
+                t.end();
+            });
+        });
+    });
+});
+
+
+test('redirect upload: DELETE /:account/uploads/:id/:partNum', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var opts = {
+            account: self.client.user
+        };
+        var pn = 0;
+        self.client.unlink(self.redirectPath(pn), opts, function (err2, res) {
+            if (ifErr(t, err2, 'redirect upload')) {
+                t.end();
+                return;
+            }
+
+            t.checkResponse(res, 301);
+            t.equal(res.headers.location, self.uploadPath(pn));
+            t.end();
+        });
+    });
+});
+
+
+test('redirect upload: non-existent id', function (t) {
+    var self = this;
+    var bogus = uuid.v4();
+    var opts = {
+        account: self.client.user
+    };
+
+    self.client.get('/' + self.client.user + '/uploads/' + bogus, opts,
+    function (err, _, res) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+
+        t.ok(verror.hasCauseWithName(err, 'ResourceNotFoundError'), err);
+        t.checkResponse(res, 404);
+        t.end();
+    });
+});

--- a/test/mpu/redirect.test.js
+++ b/test/mpu/redirect.test.js
@@ -29,6 +29,9 @@ var test = testHelper.test;
 var ifErr = helper.ifErr;
 
 
+var mpuEnabled = Boolean(require('../../etc/config.json').enableMPU);
+if (mpuEnabled) {
+
 before(function (cb) {
     helper.initMPUTester.call(this, cb);
 });
@@ -353,3 +356,5 @@ test('redirect upload: non-existent id', function (t) {
         t.end();
     });
 });
+
+} // mpuEnabled

--- a/test/mpu/upload.test.js
+++ b/test/mpu/upload.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var crypto = require('crypto');

--- a/test/mpu/upload.test.js
+++ b/test/mpu/upload.test.js
@@ -30,6 +30,9 @@ var ifErr = helper.ifErr;
 var computePartsMD5 = helper.computePartsMD5;
 
 
+var mpuEnabled = Boolean(require('../../etc/config.json').enableMPU);
+if (mpuEnabled) {
+
 before(function (cb) {
     helper.initMPUTester.call(this, cb);
 });
@@ -296,3 +299,5 @@ test('upload part: non-existent id', function (t) {
         t.end();
     });
 });
+
+} // mpuEnabled

--- a/test/mpu/upload.test.js
+++ b/test/mpu/upload.test.js
@@ -1,0 +1,298 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2017, Joyent, Inc.
+ */
+
+var crypto = require('crypto');
+var MemoryStream = require('stream').PassThrough;
+var path = require('path');
+var uuid = require('node-uuid');
+var vasync = require('vasync');
+var verror = require('verror');
+
+if (require.cache[path.join(__dirname, '/../helper.js')])
+    delete require.cache[path.join(__dirname, '/../helper.js')];
+if (require.cache[__dirname + '/helper.js'])
+    delete require.cache[__dirname + '/helper.js'];
+var testHelper = require('../helper.js');
+var helper = require('./helper.js');
+
+var after = testHelper.after;
+var before = testHelper.before;
+var test = testHelper.test;
+
+var ifErr = helper.ifErr;
+var computePartsMD5 = helper.computePartsMD5;
+
+
+before(function (cb) {
+    helper.initMPUTester.call(this, cb);
+});
+
+
+after(function (cb) {
+    helper.cleanupMPUTester.call(this, cb);
+});
+
+
+// TODO streaming object
+
+test('upload part: minimium part number', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MIN_PART_NUM;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+            t.end();
+        });
+    });
+});
+
+
+test('upload part: maximum part number', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MAX_PART_NUM;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+            t.end();
+        });
+    });
+});
+
+
+test('upload part: random part number', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.randomPartNum();
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+            t.end();
+        });
+    });
+});
+
+
+test('upload part: zero-byte part', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.randomPartNum();
+        var s = new MemoryStream();
+        var opts = {
+            size: 0
+        };
+        setImmediate(s.end.bind(s));
+
+        self.client.put(self.uploadPath(pn), s, opts, function (err2, res) {
+            if (ifErr(t, err2, 'uploaded part')) {
+                t.end();
+                return;
+            }
+
+            t.ok(res);
+            t.checkResponse(res, 204);
+            t.end();
+        });
+    });
+});
+
+
+// Upload: bad input
+
+test('upload part: part number less than allowed', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MIN_PART_NUM - 1;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 409);
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'));
+            t.end();
+        });
+    });
+});
+
+
+test('upload part: part number greater than allowed', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var pn = helper.MAX_PART_NUM + 1;
+        self.writeTestObject(self.uploadId, pn, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 409);
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'));
+            t.end();
+        });
+    });
+});
+
+
+test('upload part: setting durability-level header disallowed', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var h = {
+            'durability-level': helper.randomNumCopies()
+        };
+        var pn = helper.randomPartNum();
+        var string = 'foobar';
+        var opts = {
+            account: self.client.user,
+            md5: crypto.createHash('md5').update(string).digest('base64'),
+            size: Buffer.byteLength(string),
+            type: 'text/plain',
+            headers: h
+        };
+
+        var s = new MemoryStream();
+        self.client.put(self.uploadPath(pn), s, opts, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 409);
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'));
+            t.end();
+        });
+        setImmediate(s.end.bind(s, string));
+    });
+});
+
+
+test('upload part: setting x-durability-level header disallowed', function (t) {
+    var self = this;
+    self.createUpload(self.path, null, function (err) {
+        if (ifErr(t, err, 'created upload')) {
+            t.end();
+            return;
+        }
+
+        var h = {
+            'x-durability-level': helper.randomNumCopies()
+        };
+        var pn = helper.randomPartNum();
+        var string = 'foobar';
+        var opts = {
+            account: self.client.user,
+            md5: crypto.createHash('md5').update(string).digest('base64'),
+            size: Buffer.byteLength(string),
+            type: 'text/plain',
+            headers: h
+        };
+
+        var s = new MemoryStream();
+        self.client.put(self.uploadPath(pn), s, opts, function (err2, res) {
+            t.ok(err2);
+            if (!err2) {
+                return (t.end());
+            }
+            t.checkResponse(res, 409);
+            t.ok(verror.hasCauseWithName(err2,
+                'MultipartUploadInvalidArgumentError'));
+            t.end();
+        });
+        setImmediate(s.end.bind(s, string));
+    });
+});
+
+
+test('upload part: non-uuid id', function (t) {
+    var self = this;
+    var bogus = 'foobar';
+    var pn = helper.randomPartNum();
+    self.uploadId = bogus;
+
+    self.writeTestObject(bogus, pn, function (err, res) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err, 'DirectoryDoesNotExistError'));
+        t.checkResponse(res, 404);
+        t.end();
+    });
+});
+
+
+test('upload part: non-existent id', function (t) {
+    var self = this;
+    var bogus = uuid.v4();
+    var pn = helper.randomPartNum();
+    self.uploadId = bogus;
+
+    self.writeTestObject(bogus, pn, function (err, res) {
+        t.ok(err);
+        if (!err) {
+            return (t.end());
+        }
+        t.ok(verror.hasCauseWithName(err, 'DirectoryDoesNotExistError'));
+        t.checkResponse(res, 404);
+        t.end();
+    });
+});


### PR DESCRIPTION
This revives the MPU test parts of commit 0abfa98fdb6395fa3681d4d12367fc41c8ff7102 (MANTA-4829) that removed MPU and jobs-related tests.

Then it fixes 'make check' and skips MPU tests if MPU is not enabled in the local muskie config.