### PR TITLE
Manta 5296 muskie: DNS lookup of storage zones no longer honors TTL with cueball 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "muskie",
-    "version": "2.3.3",
+    "version": "2.3.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -447,11 +447,10 @@
             "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
         },
         "cueball": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/cueball/-/cueball-2.10.0.tgz",
-            "integrity": "sha512-RD+BM4tYF3pYMYKNwsfLJeig2i36avu5fTirg9CHQ7v3xPI7s2EHi8rotOeWf97a7ePiNE6nbmNqbiccSGOr1g==",
+            "version": "2.2.9",
+            "resolved": "https://registry.npmjs.org/cueball/-/cueball-2.2.9.tgz",
+            "integrity": "sha1-a9P3aNoTqePnYWpzvJOhIR0qZrk=",
             "requires": {
-                "artedi": "1.3.0",
                 "assert-plus": ">=1.0.0 <2.0.0",
                 "bunyan": ">=1.5.1 <2.0.0",
                 "cmdutil": ">=1.0.0 <2.0.0",
@@ -464,56 +463,6 @@
                 "uuid": ">=3.0.1 <4.0.0",
                 "vasync": ">=1.6.3 <2.0.0",
                 "verror": ">=1.6.1 <2.0.0"
-            },
-            "dependencies": {
-                "artedi": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/artedi/-/artedi-1.3.0.tgz",
-                    "integrity": "sha1-8OggNtRSX2v6SajqcvYbdlNlg+s=",
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "dtrace-provider": "0.8.6",
-                        "jsprim": "1.4.0",
-                        "vasync": "1.6.4",
-                        "verror": "1.10.0"
-                    },
-                    "dependencies": {
-                        "dtrace-provider": {
-                            "version": "0.8.6",
-                            "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
-                            "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
-                            "requires": {
-                                "nan": "^2.3.3"
-                            }
-                        }
-                    }
-                },
-                "jsprim": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                    "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                    },
-                    "dependencies": {
-                        "extsprintf": {
-                            "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-                        },
-                        "verror": {
-                            "version": "1.3.6",
-                            "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                            "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                            "requires": {
-                                "extsprintf": "1.0.2"
-                            }
-                        }
-                    }
-                }
             }
         },
         "dashdash": {
@@ -706,11 +655,16 @@
                 "kang": "^1.3.0",
                 "lstream": "0.0.4",
                 "microtime": "2.1.6",
-                "oldcrc": "git://github.com/joyent/node-crc.git#fd0477833ac28be81ada23bf84879fbde9cd8750",
                 "posix-getopt": "1.2.0",
                 "strsplit": "^1.0.0",
                 "vasync": "^1.6.3",
                 "verror": "^1.7.0"
+            },
+            "dependencies": {
+                "oldcrc": {
+                    "version": "git://github.com/joyent/node-crc.git#fd0477833ac28be81ada23bf84879fbde9cd8750",
+                    "from": "git://github.com/joyent/node-crc.git#fd0477833ac28be81ada23bf84879fbde9cd8750"
+                }
             }
         },
         "fast-deep-equal": {
@@ -1417,6 +1371,61 @@
                                 "precond": "0.2"
                             }
                         },
+                        "cueball": {
+                            "version": "2.10.1",
+                            "resolved": "https://registry.npmjs.org/cueball/-/cueball-2.10.1.tgz",
+                            "integrity": "sha512-bVaO4Opo2VdXiSROdjLY8ib7KIXknezTDTokqjRhB0xONIVYSEbUhadC78J4/fgLv7dQDratFwSoaUU5mcTB3A==",
+                            "requires": {
+                                "artedi": "~2.0.2",
+                                "assert-plus": ">=1.0.0 <2.0.0",
+                                "bunyan": ">=1.5.1 <2.0.0",
+                                "cmdutil": ">=1.0.0 <2.0.0",
+                                "dtrace-provider": "~0.8",
+                                "extsprintf": ">=1.3.0 <2.0.0",
+                                "ipaddr.js": ">=1.1.0 <2.0.0",
+                                "mname-client": ">=0.5.0 <0.6.0",
+                                "mooremachine": ">=2.2.0 <3.0.0",
+                                "posix-getopt": ">=1.2.0 <2.0.0",
+                                "uuid": ">=3.0.1 <4.0.0",
+                                "vasync": ">=1.6.3 <2.0.0",
+                                "verror": ">=1.6.1 <2.0.0"
+                            },
+                            "dependencies": {
+                                "artedi": {
+                                    "version": "2.0.2",
+                                    "resolved": "https://registry.npmjs.org/artedi/-/artedi-2.0.2.tgz",
+                                    "integrity": "sha512-nEg+hnqdCIUw4TbtLC6W68NbXg/udbU0/tGe3pgqPd+PysbvxoM1RlmD0TKq8/ovr7iPNtgG4hNE1YxLS++6QA==",
+                                    "requires": {
+                                        "assert-plus": "^1.0.0",
+                                        "dtrace-provider": "^0.8.8",
+                                        "jsprim": "^2.0.0",
+                                        "vasync": "^1.6.4",
+                                        "verror": "^1.10.0"
+                                    },
+                                    "dependencies": {
+                                        "dtrace-provider": {
+                                            "version": "0.8.8",
+                                            "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+                                            "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+                                            "requires": {
+                                                "nan": "^2.14.0"
+                                            }
+                                        }
+                                    }
+                                },
+                                "jsprim": {
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.0.tgz",
+                                    "integrity": "sha1-Wl2aNXcJeGAKHKoJXHjHgx7PT3w=",
+                                    "requires": {
+                                        "assert-plus": "1.0.0",
+                                        "extsprintf": "1.3.0",
+                                        "json-schema": "0.2.3",
+                                        "verror": "1.10.0"
+                                    }
+                                }
+                            }
+                        },
                         "vasync": {
                             "version": "1.6.4",
                             "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.4.tgz",
@@ -2119,6 +2128,28 @@
                 "progbar": "0.1.0",
                 "vasync": "^1.6.4",
                 "verror": "^1.9.0"
+            },
+            "dependencies": {
+                "cueball": {
+                    "version": "2.10.1",
+                    "resolved": "https://registry.npmjs.org/cueball/-/cueball-2.10.1.tgz",
+                    "integrity": "sha512-bVaO4Opo2VdXiSROdjLY8ib7KIXknezTDTokqjRhB0xONIVYSEbUhadC78J4/fgLv7dQDratFwSoaUU5mcTB3A==",
+                    "requires": {
+                        "artedi": "~2.0.2",
+                        "assert-plus": ">=1.0.0 <2.0.0",
+                        "bunyan": ">=1.5.1 <2.0.0",
+                        "cmdutil": ">=1.0.0 <2.0.0",
+                        "dtrace-provider": "~0.8",
+                        "extsprintf": ">=1.3.0 <2.0.0",
+                        "ipaddr.js": ">=1.1.0 <2.0.0",
+                        "mname-client": ">=0.5.0 <0.6.0",
+                        "mooremachine": ">=2.2.0 <3.0.0",
+                        "posix-getopt": ">=1.2.0 <2.0.0",
+                        "uuid": ">=3.0.1 <4.0.0",
+                        "vasync": ">=1.6.3 <2.0.0",
+                        "verror": ">=1.6.1 <2.0.0"
+                    }
+                }
             }
         },
         "moray-filter": {
@@ -2270,10 +2301,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
-        },
-        "oldcrc": {
-            "version": "git://github.com/joyent/node-crc.git#fd0477833ac28be81ada23bf84879fbde9cd8750",
-            "from": "git://github.com/joyent/node-crc.git#0.3.0-oldcrc"
         },
         "once": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "muskie",
     "description": "Manta public-facing WebAPI",
-    "version": "2.3.3",
+    "version": "2.4.3",
     "author": "Joyent (joyent.com)",
     "private": true,
     "repository": {
@@ -19,7 +19,7 @@
         "cmdln": "4.3.0",
         "content-disposition": "0.5.3",
         "content-type": "1.0.4",
-        "cueball": "2.10.0",
+        "cueball": "2.2.9",
         "dashdash": "1.14.1",
         "deep-equal": "0.0.0",
         "dtrace-provider": "0.8.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "muskie",
     "description": "Manta public-facing WebAPI",
-    "version": "2.4.3",
+    "version": "2.3.4",
     "author": "Joyent (joyent.com)",
     "private": true,
     "repository": {


### PR DESCRIPTION
The change downgrades cueball back to 2.2.9, the version used prior to the 2.10.0 upgrade. A separate ticket will be made for the necessary cueball fix.

Please see JIRA ticket for test notes.