### PR TITLE
MANTA-5004 Update webapi to use the storinfo service (fix test suite)

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1085,7 +1085,7 @@ module.exports = {
             // Write request setup
             if (!req.isReadOnly()) {
                 if (clients.storinfo !== undefined) {
-                    req.picker = clients.storinfo;
+                    req.storinfo = clients.storinfo;
                 } else {
                     req.picker = clients.picker;
                 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -645,6 +645,11 @@ function translateError(err, req) {
     if (err instanceof MuskieError || err instanceof restifyErrors.HttpError)
         return (err);
 
+    // Allow known error names from node-storinfo.
+    if (err.name === 'NotEnoughSpaceError') {
+        return (err);
+    }
+
     var cause;
 
     // A NoDatabasePeersError with a context object that has a 'name' and a

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -645,11 +645,6 @@ function translateError(err, req) {
     if (err instanceof MuskieError || err instanceof restifyErrors.HttpError)
         return (err);
 
-    // Allow known error names from node-storinfo.
-    if (err.name === 'NotEnoughSpaceError') {
-        return (err);
-    }
-
     var cause;
 
     // A NoDatabasePeersError with a context object that has a 'name' and a

--- a/lib/obj.js
+++ b/lib/obj.js
@@ -81,6 +81,8 @@ var DATA_TIMEOUT = parseInt(process.env.MUSKIE_DATA_TIMEOUT || 45000, 10);
 // Upper bound of 1 million entries in a directory.
 var MAX_DIRENTS = 1000000;
 
+var BYTES_IN_MB = 1048576;
+
 /*
  * Default minimum and maximum number of copies of an object we will store,
  * as specified in the {x-}durability-level header.
@@ -309,13 +311,25 @@ function findSharks(req, res, next) {
         size: req._size,
         isOperator: req.caller.account.isOperator
     };
+    var picker = req.storinfo || req.picker;
 
     log.debug(opts, 'findSharks: entered');
 
     opts.log = req.log;
-    req.picker.choose(opts, function (err, sharks) {
+    picker.choose(opts, function (err, sharks) {
         if (err) {
-            next(err);
+            if (req.storinfo) {
+                // Must wrap node-storinfo errors in Muskie's own error
+                // class for correct `translateError()` handling, response
+                // status, and "code" in error response body.
+                //
+                // Note: `picker.choose()` takes `size` in bytes, but
+                // `NotEnoughSpaceError` takes `size` in MB.
+                next(new NotEnoughSpaceError(
+                    Math.ceil(opts.size / BYTES_IN_MB), err));
+            } else {
+                next(err);
+            }
         } else {
             req._sharks = sharks;
             log.debug({

--- a/lib/uploads/create.js
+++ b/lib/uploads/create.js
@@ -36,6 +36,8 @@ require('../errors');
 
 ///--- Globals
 
+var BYTES_IN_MB = 1048576;
+
 var hasKey = jsprim.hasKey;
 var sprintf = util.format;
 var schemaValidator = ajv.compile({
@@ -89,9 +91,21 @@ function chooseSharks(req, size, copies, cb) {
             replicas: copies,
             size: size
         };
-        req.picker.choose(opts, function (err, sharks) {
+        var picker = req.storinfo || req.picker;
+        picker.choose(opts, function (err, sharks) {
             if (err) {
-                cb(err);
+                if (req.storinfo) {
+                    // Must wrap node-storinfo errors in Muskie's own error
+                    // class for correct `translateError()` handling, response
+                    // status, and "code" in error response body.
+                    //
+                    // Note: `picker.choose()` takes `size` in bytes, but
+                    // `NotEnoughSpaceError` takes `size` in MB.
+                    cb(new NotEnoughSpaceError(
+                        Math.ceil(opts.size / BYTES_IN_MB), err));
+                } else {
+                    cb(err);
+                }
             } else {
                 log.debug({
                     sharks: sharks[0]


### PR DESCRIPTION
This fixes webapi's "translateError" to accept a known error name from
node-storinfo.