### PR TITLE
MANTA-2926 Support Accept-Encoding / Content-Encoding gzip, deflate (revert: needs more work)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -269,7 +269,6 @@ function createServer(options, clients, name) {
 
     server.use(common.earlySetupHandler(options));
     server.use(restify.plugins.dateParser(options.maxRequestAge || 300));
-    server.use(restify.plugins.gzipResponse());
     server.use(restify.plugins.queryParser());
     server.use(common.authorizationParser);
     server.use(auth.checkIfPresigned);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "muskie",
     "description": "Manta public-facing WebAPI",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "author": "Joyent (joyent.com)",
     "private": true,
     "repository": {


### PR DESCRIPTION
This reverts MANTA-2926 / c49136302a8079f48b9093e9ab30d7ec565fe700 pending more work, since that change caused unanticipated issues for some users of the java-manta client.